### PR TITLE
(Closes #29) Allow include tests and skip tests to be set at the same time.

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -121,6 +121,39 @@
     XCTAssert(found == 2); // We must have found both testcases
 }
 
+- (void)testRunningAndIgnoringCertainTestCases {
+    NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppPassingTests", tempDir] withError:nil];
+    // NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+    self.config.junitOutput = NO;
+    self.config.plainOutput = YES;
+    self.config.errorRetriesCount = @2;
+    self.config.testCasesToRun = @[
+                                   @"BPSampleAppTests/testCase173",
+                                   @"BPSampleAppTests/testCase199"
+                                   ];
+    
+    self.config.testCasesToSkip = @[@"BPSampleAppTests/testCase173"];
+    
+    BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
+    XCTAssert(exitCode == BPExitStatusTestsAllPassed);
+    
+    NSString *textReportPath = [outputDir stringByAppendingPathComponent:@"1-BPSampleAppTests-results.txt"];
+    NSString *contents = [NSString stringWithContentsOfFile:textReportPath encoding:NSUTF8StringEncoding error:nil];
+    // We'll go line by line asserting we didn't run any extra testcases.
+    NSArray *lines = [contents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    int found = 0;
+    for (NSString *line in lines) {
+        if ([line rangeOfString:@"testCase"].location == NSNotFound) continue;
+        XCTAssert([line containsString:@"testCase199"]);
+        if ([line containsString:@"testCase199"]) found++;
+    }
+    XCTAssert(found == 1); // We must have found both testcases
+}
+
 - (void)testReportWithAppCrashingTestsSet {
     NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -45,7 +45,9 @@
     [xctConfig setReportResultsToIDE:NO];
     if (config.testCasesToSkip) {
         [xctConfig setTestsToSkip:[NSSet setWithArray:config.testCasesToSkip]];
-    } else if (config.testCasesToRun) {
+    }
+    
+    if (config.testCasesToRun) {
         // According to @khu, we can't just pass the right setTestsToRun and have it work, so what we do instead
         // is get the full list of tests from the XCTest bundle, then skip everything we don't want to run.
         NSError *error;
@@ -57,10 +59,13 @@
             [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to load testcases from %@", [error localizedDescription]]];
             [BPUtils printInfo:WARNING withString:@"Will Run all TestCases"];
         } else {
-            NSMutableSet *allTestCases = [[NSMutableSet alloc] initWithArray:xctTestFile.allTestCases];
+            NSMutableSet *testsToSkip = [[NSMutableSet alloc] initWithArray:xctTestFile.allTestCases];
             NSSet *testsToRun = [[NSSet alloc] initWithArray:config.testCasesToRun];
-            [allTestCases minusSet:testsToRun];
-            [xctConfig setTestsToSkip:allTestCases];
+            [testsToSkip minusSet:testsToRun];
+            if (xctConfig.testsToSkip) {
+                [testsToSkip unionSet:xctConfig.testsToSkip];
+            }
+            [xctConfig setTestsToSkip:testsToSkip];
         }
     }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -55,18 +55,14 @@
         NSString *executable = [config.testBundlePath stringByAppendingPathComponent:basename];
 
         BPXCTestFile *xctTestFile = [BPXCTestFile BPXCTestFileFromExecutable:executable withError:&error];
-        if (!xctTestFile) {
-            [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to load testcases from %@", [error localizedDescription]]];
-            exit(1);
-        } else {
-            NSMutableSet *testsToSkip = [[NSMutableSet alloc] initWithArray:xctTestFile.allTestCases];
-            NSSet *testsToRun = [[NSSet alloc] initWithArray:config.testCasesToRun];
-            [testsToSkip minusSet:testsToRun];
-            if (xctConfig.testsToSkip) {
-                [testsToSkip unionSet:xctConfig.testsToSkip];
-            }
-            [xctConfig setTestsToSkip:testsToSkip];
+        NSAssert(xctTestFile != nil, @"Failed to load testcases from %@", [error localizedDescription]);
+        NSMutableSet *testsToSkip = [[NSMutableSet alloc] initWithArray:xctTestFile.allTestCases];
+        NSSet *testsToRun = [[NSSet alloc] initWithArray:config.testCasesToRun];
+        [testsToSkip minusSet:testsToRun];
+        if (xctConfig.testsToSkip) {
+            [testsToSkip unionSet:xctConfig.testsToSkip];
         }
+        [xctConfig setTestsToSkip:testsToSkip];
     }
 
     NSString *XCTestConfigurationFilename = [NSString stringWithFormat:@"%@/%@-%@",

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -57,7 +57,7 @@
         BPXCTestFile *xctTestFile = [BPXCTestFile BPXCTestFileFromExecutable:executable withError:&error];
         if (!xctTestFile) {
             [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to load testcases from %@", [error localizedDescription]]];
-            [BPUtils printInfo:WARNING withString:@"Will Run all TestCases"];
+            exit(1);
         } else {
             NSMutableSet *testsToSkip = [[NSMutableSet alloc] initWithArray:xctTestFile.allTestCases];
             NSSet *testsToRun = [[NSSet alloc] initWithArray:config.testCasesToRun];

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ A full list supported options are listed here.
 |    `scheme-path`   |           -s           | The scheme to run tests                                                            |     Y    | n/a              |
 |       config       |           -c           | Read options from the specified configuration file instead of the command line     |     N    | n/a              |
 |       device       |           -d           | On which device to run the app.                                                    |     N    | iPhone 6         |
-|       exclude      |           -x           | Exclude a testcase in the set of tests to run                                      |     N    | empty            |
+|       exclude      |           -x           | Exclude a testcase in the set of tests to run  (takes priority over `include`).    |     N    | empty            |
 |      headless      |           -H           | Run in headless mode (no GUI).                                                     |     N    | off              |
 |      xcode-path    |           -x           | Path to xcode.                                                                     |     N    | xcode-select -p  |
-|       include      |           -i           | Include a testcase in the set of tests to run.                                     |     N    | all tests        |
+|       include      |           -i           | Include a testcase in the set of tests to run (unless specified in `exclude`).     |     N    | all tests        |
 |     json-output    |           -J           | Print test timing information in JSON format.                                      |     N    | off              |
 |    junit-output    |           -j           | Print results in JUnit format.                                                     |     N    | true             |
 |     list-tests     |           -l           | Only list tests in bundle                                                          |     N    | false            |

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -59,7 +59,7 @@ struct BPOptions {
     {'f', "failure-tolerance",   required_argument, NO, BP_VALUE, "failureTolerance",
         "The number of retries on any failures (app crash/test failure)."},
     {'i', "include", required_argument, NULL, BP_LIST, "testCasesToRun",
-        "Include a testcase in the set of tests to run."},
+        "Include a testcase in the set of tests to run (unless specified in `exclude`)."},
     {'n', "num-sims", required_argument, "4", BP_VALUE, "numSims",
         "Number of simulators to run in parallel. (bluepill only)"},
     {'r', "runtime",  required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
@@ -67,7 +67,7 @@ struct BPOptions {
     {'t', "test",     required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
         "The path to the test bundle to execute (your .xctest)."},
     {'x', "exclude", required_argument, NULL, BP_LIST, "testCasesToSkip",
-        "Exclude a testcase in the set of tests to run."},
+        "Exclude a testcase in the set of tests to run (takes priority over `include`)."},
     {'X', "xcode-path", required_argument, NULL, BP_VALUE | BP_PATH, "xcodePath",
         "Path to xcode."},
 


### PR DESCRIPTION
This prioritizes skipped tests over included tests.