### PR TITLE
Correctly partition tests when only testing a subset.

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPPacker.h
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.h
@@ -18,6 +18,6 @@
  * @param numBundles The number of bundles to pack the xctest files into. Note that this is a guideline, the returned number of bundles can differ from this argument.
  * @return An NSMutableArray of BPBundle's with the tests packed into bundles.
  */
-+ (NSMutableArray *)packTests:(NSArray *)xcTestFiles withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error;
++ (NSMutableArray *)packTests:(NSArray *)xcTestFiles testCasesToRun:(NSArray *)testCasesToRun withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPPacker.h
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.h
@@ -18,6 +18,10 @@
  * @param numBundles The number of bundles to pack the xctest files into. Note that this is a guideline, the returned number of bundles can differ from this argument.
  * @return An NSMutableArray of BPBundle's with the tests packed into bundles.
  */
-+ (NSMutableArray *)packTests:(NSArray *)xcTestFiles testCasesToRun:(NSArray *)testCasesToRun withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error;
++ (NSMutableArray *)packTests:(NSArray *)xcTestFiles
+               testCasesToRun:(NSArray *)testCasesToRun
+              withNoSplitList:(NSArray *)noSplit
+                  intoBundles:(NSUInteger)numBundles
+                     andError:(NSError **)error;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -15,7 +15,11 @@
 
 @implementation BPPacker
 
-+ (NSMutableArray *)packTests:(NSArray *)xcTestFiles testCasesToRun:(NSArray *)testCasesToRun withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error {
++ (NSMutableArray *)packTests:(NSArray *)xcTestFiles
+               testCasesToRun:(NSArray *)testCasesToRun
+              withNoSplitList:(NSArray *)noSplit
+                  intoBundles:(NSUInteger)numBundles
+                     andError:(NSError **)error {
     NSArray *sortedXCTestFiles = [xcTestFiles sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
         NSUInteger numTests1 = [(BPXCTestFile *)obj1 numTests];
         NSUInteger numTests2 = [(BPXCTestFile *)obj2 numTests];
@@ -35,13 +39,13 @@
     NSUInteger totalTests = 0;
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
         if (![noSplit containsObject:[xctFile name]]) {
-            NSMutableSet *testsToRun = [[NSMutableSet alloc] initWithArray:[xctFile allTestCases]];
+            NSMutableSet *bundleTestsToRun = [[NSMutableSet alloc] initWithArray:[xctFile allTestCases]];
             if (testCasesToRun) {
-                [testsToRun intersectSet:[[NSSet alloc] initWithArray:testCasesToRun]];
+                [bundleTestsToRun intersectSet:[[NSSet alloc] initWithArray:testCasesToRun]];
             }
-            if (testsToRun.count > 0) {
-                testsToRunByTestFilePath[xctFile.path] = testsToRun;
-                totalTests += testsToRun.count;
+            if (bundleTestsToRun.count > 0) {
+                testsToRunByTestFilePath[xctFile.path] = bundleTestsToRun;
+                totalTests += bundleTestsToRun.count;
             }
         }
     }

--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -15,8 +15,7 @@
 
 @implementation BPPacker
 
-+ (NSMutableArray *)packTests:(NSArray *)xcTestFiles withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error {
-    NSUInteger totalTests = 0;
++ (NSMutableArray *)packTests:(NSArray *)xcTestFiles testCasesToRun:(NSArray *)testCasesToRun withNoSplitList:(NSArray *)noSplit intoBundles:(NSUInteger)numBundles andError:(NSError **)error {
     NSArray *sortedXCTestFiles = [xcTestFiles sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
         NSUInteger numTests1 = [(BPXCTestFile *)obj1 numTests];
         NSUInteger numTests2 = [(BPXCTestFile *)obj2 numTests];
@@ -32,34 +31,28 @@
         }
         return NULL;
     }
+    NSMutableDictionary *testsToRunByTestFilePath = [[NSMutableDictionary alloc] init];
+    NSUInteger totalTests = 0;
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
         if (![noSplit containsObject:[xctFile name]]) {
-            totalTests += [xctFile numTests];
+            NSMutableSet *testsToRun = [[NSMutableSet alloc] initWithArray:[xctFile allTestCases]];
+            if (testCasesToRun) {
+                [testsToRun intersectSet:[[NSSet alloc] initWithArray:testCasesToRun]];
+            }
+            if (testsToRun.count > 0) {
+                testsToRunByTestFilePath[xctFile.path] = testsToRun;
+                totalTests += testsToRun.count;
+            }
         }
     }
-    NSUInteger testsPerGroup = totalTests/numBundles;
-    if (testsPerGroup < 1) {
-        // We are trying to pack too few tests into too many bundles
-        if (error) {
-            *error = [NSError errorWithDomain:BPErrorDomain
-                                         code:-1
-                                     userInfo:@{NSLocalizedDescriptionKey:
-                                                    [NSString stringWithFormat:
-                                                        @"Trying to pack too few tests (%lu) into too many bundles (%lu).",
-                                                        (unsigned long)totalTests, (unsigned long)numBundles
-                                                     ]}];
-        }
-        return NULL;
-    }
+    NSUInteger testsPerGroup = MAX(1, totalTests / numBundles);
     NSMutableArray *bundles = [[NSMutableArray alloc] init];
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
+        NSArray *bundleTestsToRun = [[testsToRunByTestFilePath[xctFile.path] allObjects] sortedArrayUsingSelector:@selector(compare:)];
+        NSUInteger bundleTestsToRunCount = [bundleTestsToRun count];
         // if the xctfile is in nosplit list, don't pack it
-        if ([noSplit containsObject:[xctFile name]] || [xctFile numTests] < testsPerGroup) {
+        if ([noSplit containsObject:[xctFile name]] || (bundleTestsToRunCount <= testsPerGroup && bundleTestsToRunCount > 0)) {
             // just pack the whole xctest file and move on
-            NSRange range;
-            range.location = 0;
-            range.length = [xctFile numTests];
-
             // testsToRun doesn't work reliably, switch to use testsToSkip
             BPBundle *bundle = [[BPBundle alloc] initWithPath:xctFile.path andTestsToSkip:@[]];
 
@@ -70,19 +63,18 @@
 
         // We don't want to pack tests from different xctest bundles so we just split
         // the current test bundle in chunks and pack those.
-        NSArray *allTestCases = [xctFile allTestCases];
+        NSArray *allTestCases = [[xctFile allTestCases] sortedArrayUsingSelector:@selector(compare:)];
         NSUInteger packed = 0;
-        while (packed < allTestCases.count) {
+        while (packed < bundleTestsToRun.count) {
             NSRange range;
             range.location = packed;
-            range.length = min(testsPerGroup, allTestCases.count - packed);
+            range.length = min(testsPerGroup, bundleTestsToRun.count - packed);
             NSMutableArray *testsToSkip = [NSMutableArray arrayWithArray:allTestCases];
-            [testsToSkip removeObjectsInArray:[allTestCases subarrayWithRange:range]];
-            NSArray *testsToSkipSorted = [testsToSkip sortedArrayUsingSelector:@selector(compare:)];
-            [bundles addObject:[[BPBundle alloc] initWithPath:xctFile.path andTestsToSkip:testsToSkipSorted]];
+            [testsToSkip removeObjectsInArray:[bundleTestsToRun subarrayWithRange:range]];
+            [bundles addObject:[[BPBundle alloc] initWithPath:xctFile.path andTestsToSkip:testsToSkip]];
             packed += range.length;
         }
-        assert(packed == [xctFile numTests]);
+        assert(packed == [bundleTestsToRun count]);
     }
     return bundles;
 }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -123,25 +123,17 @@ maxprocs(void)
     signal(SIGINT, onInterrupt);
     
     NSUInteger numSims = [self.config.numSims intValue];
-    NSUInteger origNumSims = numSims;
     [BPUtils printInfo:INFO withString:@"This is Bluepill %s", BP_VERSION];
     NSError *error;
-    NSMutableArray *bundles = [BPPacker packTests:self.app.testBundles withNoSplitList:self.config.noSplit intoBundles:numSims andError:&error];
-    while (!bundles && numSims > 1) {
-        // packTests fails if we're trying to pack < N tests into N bundles, so just reduce the number of simulators and try again
-        // treat the error as a warning and try again.
-        [BPUtils printInfo:WARNING withString:[error localizedDescription]];
-        numSims--;
-        bundles = [BPPacker packTests:self.app.testBundles withNoSplitList:self.config.noSplit intoBundles:numSims andError:&error];
-    }
-    if (!bundles) {
+    NSMutableArray *bundles = [BPPacker packTests:self.app.testBundles testCasesToRun:self.config.testCasesToRun withNoSplitList:self.config.noSplit intoBundles:numSims andError:&error];
+    if (!bundles || bundles.count == 0) {
         [BPUtils printInfo:ERROR withString:@"Packing failed: %@", [error localizedDescription]];
         return 1;
     }
-    if (numSims != origNumSims) {
+    if (bundles.count != numSims) {
         [BPUtils printInfo:WARNING
                 withString:[NSString stringWithFormat:@"Lowering number of simulators from %lu to %lu because there aren't enough tests.",
-                            origNumSims, numSims]];
+                            numSims, bundles.count]];
     }
     [BPUtils printInfo:INFO withString:[NSString stringWithFormat:@"Running with %lu simulator%s.",
                                         (unsigned long)numSims, (numSims > 1) ? "s" : ""]];

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -130,7 +130,7 @@ maxprocs(void)
         [BPUtils printInfo:ERROR withString:@"Packing failed: %@", [error localizedDescription]];
         return 1;
     }
-    if (bundles.count != numSims) {
+    if (bundles.count < numSims) {
         [BPUtils printInfo:WARNING
                 withString:[NSString stringWithFormat:@"Lowering number of simulators from %lu to %lu because there aren't enough tests.",
                             numSims, bundles.count]];

--- a/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
@@ -83,17 +83,19 @@
     }
     allTests = [tests sortedArrayUsingSelector:@selector(compare:)];
     // Make sure we don't split when we don't want to
-    bundles = [BPPacker packTests:app.testBundles withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
+    bundles = [BPPacker packTests:app.testBundles testCasesToRun:nil withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
     // When we prevent BPSampleTests from splitting, BPSampleAppFatalErrorTests gets split in two
     want = [[want arrayByAddingObject:@"BPSampleAppFatalErrorTests"] sortedArrayUsingSelector:@selector(compare:)];
     XCTAssert(bundles.count == app.testBundles.count + 1);
 
     XCTAssert([bundles[0].testsToSkip count] == 0);
     XCTAssert([bundles[1].testsToSkip count] == 0);
-    XCTAssert([bundles[2].testsToSkip count] == 2);
-    XCTAssert([bundles[3].testsToSkip count] == 3);
+    XCTAssert([bundles[2].testsToSkip count] == 0);
+    XCTAssert([bundles[3].testsToSkip count] == 0);
+    XCTAssert([bundles[4].testsToSkip count] == 2);
+    XCTAssert([bundles[5].testsToSkip count] == 3);
 
-    bundles = [BPPacker packTests:app.testBundles withNoSplitList:@[]  intoBundles:4 andError:nil];
+    bundles = [BPPacker packTests:app.testBundles testCasesToRun:nil withNoSplitList:@[]  intoBundles:4 andError:nil];
     // 4 unbreakable bundles (too few tests) and the big one broken into 4 bundles
     XCTAssert(bundles.count == 8);
     // All we want to test is that we have full coverage
@@ -106,11 +108,11 @@
     XCTAssert([bundles[6].testsToSkip count] == 148);
     XCTAssert([bundles[7].testsToSkip count] == 159);
 
-    bundles = [BPPacker packTests:app.testBundles withNoSplitList:nil intoBundles:1 andError:nil];
+    bundles = [BPPacker packTests:app.testBundles testCasesToRun:nil withNoSplitList:nil intoBundles:1 andError:nil];
     // If we pack into just one bundle, we can't have less bundles than the total number of .xctest files.
     XCTAssert(bundles.count == app.testBundles.count);
 
-    bundles = [BPPacker packTests:app.testBundles withNoSplitList:nil intoBundles:16 andError:nil];
+    bundles = [BPPacker packTests:app.testBundles testCasesToRun:nil withNoSplitList:nil intoBundles:16 andError:nil];
 
     XCTAssert([bundles[0].testsToSkip count] == 0);
     XCTAssert([bundles[1].testsToSkip count] == 0);
@@ -132,6 +134,17 @@
     XCTAssert([bundles[17].testsToSkip count] == 188);
     XCTAssert([bundles[18].testsToSkip count] == 188);
     XCTAssert([bundles[19].testsToSkip count] == 195);
+    
+    NSMutableArray *toRun = [[NSMutableArray alloc] init];
+    for (long i = 1; i <= 20; i++) {
+        [toRun addObject:[NSString stringWithFormat:@"BPSampleAppTests/testCase%03ld", i]];
+    }    
+    bundles = [BPPacker packTests:app.testBundles testCasesToRun:toRun withNoSplitList:nil intoBundles:4 andError:nil];
+    
+    XCTAssertEqual(bundles.count, 4);
+    for (BPBundle *bundle in bundles) {
+        XCTAssertEqual(bundle.testsToSkip.count, 196);
+    }
 }
 
 - (void)testNoSplittingOfExtraTestBundles {
@@ -154,7 +167,7 @@
                                      withError:nil];
     XCTAssert(app != nil);
 
-    NSArray *bundles = [BPPacker packTests:app.testBundles withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
+    NSArray *bundles = [BPPacker packTests:app.testBundles testCasesToRun:nil withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
     BOOL found = false;
     for (BPBundle *bundle in bundles) {
         if ([[bundle.path lastPathComponent] isEqualToString:@"BPSampleAppTests.xctest"]) {


### PR DESCRIPTION
If a bundle had 100 tests and you specify the first 10 with the `include` option on 5 simulators, instead of running 2 tests on each simulator, it would run all 10 on one simulator, then start up and run 0 tests on the other 4. This fixes that.