### PR TITLE
Try to handle the hang-after-timeout issue #38

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -211,8 +211,12 @@ typedef NS_ENUM(NSInteger, SimulatorState) {
     if (![[self.device stateString] isEqualToString:@"Shutdown"]) {
         // self.appPID can be zero when running the parsing tests
         // since we're not actually creating a simulator and running an app.
+        [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
         if (self.appPID && (kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGTERM) < 0)) {
+            [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d", self.appPID];
             perror("kill");
+        } else {
+            [BPUtils printInfo:ERROR withString:@"Success killing the process with appPID: %d", self.appPID];
         }
     }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorRunner.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorRunner.m
@@ -276,17 +276,21 @@
     self.monitor.hostBundleId = hostBundleId;
     parser.delegate = self.monitor;
 
+    // Keep the simulator runner around through processing of the block
+    __block typeof(self) blockSelf = self;
+
     [self.device launchApplicationAsyncWithID:hostBundleId options:options completionHandler:^(NSError *error, pid_t pid) {
+        // Save the process ID to the monitor
+        blockSelf.monitor.appPID = pid;
+
         if (error == nil) {
             dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_PROC, pid, DISPATCH_PROC_EXIT, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0));
             dispatch_source_set_event_handler(source, ^{
                 dispatch_source_cancel(source);
             });
-            __block __weak SimulatorRunner *weakSelf = self;
-            weakSelf.monitor.appPID = pid;
             dispatch_source_set_cancel_handler(source, ^{
                 // Post a APPCLOSED signal to the fifo
-                [weakSelf.stdOutHandle writeData:[@"\nBP_APP_PROC_ENDED\n" dataUsingEncoding:NSUTF8StringEncoding]];
+                [blockSelf.stdOutHandle writeData:[@"\nBP_APP_PROC_ENDED\n" dataUsingEncoding:NSUTF8StringEncoding]];
             });
             dispatch_resume(source);
             self.stdOutHandle.readabilityHandler = ^(NSFileHandle *handle) {


### PR DESCRIPTION
- Ensure the runner remains around for the lifetime of the launch application block
- Add more logging around killing the app in the simulator in case the above fix doesn't do anything