### PR TITLE
Fix hangs

### DIFF
--- a/BPSampleApp/BPSampleApp/AppDelegate.m
+++ b/BPSampleApp/BPSampleApp/AppDelegate.m
@@ -20,6 +20,17 @@
     // Override point for customization after application launch.
 
     // This is a sample app for Bluepill testing.
+    if (getenv("_BP_TEST_CRASH_ON_LAUNCH")) {
+        char *p = NULL;
+        NSLog(@"CRASHING AT USER'S REQUEST");
+        strcpy(p, "I know this will crash my app");
+    }
+    if (getenv("_BP_TEST_HANG_ON_LAUNCH")) {
+        NSLog(@"HANGING AT USER'S REQUEST");
+        while(1) {
+            sleep(10);
+        }
+    }
     return YES;
 }
 

--- a/Bluepill-cli/BPInstanceTests/BPTreeParserTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPTreeParserTests.m
@@ -19,6 +19,8 @@
 
 @interface BPTreeParserTests : XCTestCase
 
+@property (nonatomic, strong) BPConfiguration* config;
+
 @end
 
 @implementation BPTreeParserTests
@@ -29,6 +31,8 @@
         [BPUtils quietMode:YES];
         [BPUtils enableDebugOutput:NO];
     }
+    self.config = [[BPConfiguration alloc] init];
+    self.config.testing_NoAppWillRun = YES;
 }
 
 - (void)tearDown {
@@ -53,8 +57,7 @@ BPWriter *getWriter() {
 
     BPWriter *writer = getWriter();
     BPTreeParser *parser = [[BPTreeParser alloc] initWithWriter:writer];
-    BPConfiguration *config = [[BPConfiguration alloc] init];
-    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:config];
+    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:self.config];
 
     parser.delegate = monitor;
 
@@ -74,8 +77,7 @@ BPWriter *getWriter() {
     
     BPWriter *writer = getWriter();
     BPTreeParser *parser = [[BPTreeParser alloc] initWithWriter:writer];
-    BPConfiguration *config = [[BPConfiguration alloc] init];
-    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:config];
+    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:self.config];
 
     parser.delegate = monitor;
 
@@ -95,8 +97,7 @@ BPWriter *getWriter() {
     
     BPWriter *writer = getWriter();
     BPTreeParser *parser = [[BPTreeParser alloc] initWithWriter:writer];
-    BPConfiguration *config = [[BPConfiguration alloc] init];
-    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:config];
+    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:self.config];
 
     parser.delegate = monitor;
 
@@ -116,8 +117,7 @@ BPWriter *getWriter() {
     
     BPWriter *writer = getWriter();
     BPTreeParser *parser = [[BPTreeParser alloc] initWithWriter:writer];
-    BPConfiguration *config = [[BPConfiguration alloc] init];
-    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:config];
+    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:self.config];
     monitor.maxTimeWithNoOutput = 2.0; // change the max output time to 2 seconds
 
     parser.delegate = monitor;
@@ -145,8 +145,7 @@ BPWriter *getWriter() {
     
     BPWriter *writer = getWriter();
     BPTreeParser *parser = [[BPTreeParser alloc] initWithWriter:writer];
-    BPConfiguration *config = [[BPConfiguration alloc] init];
-    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:config];
+    SimulatorMonitor *monitor = [[SimulatorMonitor alloc] initWithConfiguration:self.config];
 
     parser.delegate = monitor;
 

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -78,16 +78,25 @@
     [super tearDown];
 }
 
-// This is a template to run Voyager's tests
-- (void)testVoyager {
-//    self.config.outputDirectory = @"/Users/khu/tmp/simulator";
-//    self.config.schemePath = @"/Users/khu/ios/mntf-ios-sample-app_trunk/./mntf-ios-sample-app.xcodeproj/xcshareddata/xcschemes/mntf-ios-sample-app-ui-tests.xcscheme";
-//    self.config.testCasesToRun = @[@"MNTFSampleAppUITests/testRotate", @"MNTFSampleAppUITests/testScrollToAnIndex"];
-//    self.config.appBundlePath =
-//    @"/Users/khu/ios/mntf-ios-sample-app_trunk/build/mntf-ios-sample-app/Build/Products/Debug-iphonesimulator/mntf-ios-sample-app.app";
-//    self.config.testBundlePath = @"/Users/khu/ios/mntf-ios-sample-app_trunk/build/mntf-ios-sample-app/Build/Products/Debug-iphonesimulator/mntf-ios-sample-app.app/PlugIns/mntf-ios-sample-app-UITests.xctest";
-//    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+- (void)testAppThatCrashesOnLaunch {
+    NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];
+    self.config.testBundlePath = testBundlePath;
+    self.config.testing_CrashAppOnLaunch = YES;
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    NSLog(@"%ld", (long)exitCode);
+    XCTAssert(exitCode == BPExitStatusAppCrashed);
+    
 }
+
+- (void)testAppThatHangsOnLaunch {
+    NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];
+    self.config.testBundlePath = testBundlePath;
+    self.config.testing_HangAppOnLaunch = YES;
+    BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
+    NSLog(@"%ld", (long)exitCode);
+    //XCTAssert(exitCode == BPExitStatusAppHung);
+}
+
 
 - (void)testRunningOnlyCertainTestcases {
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -85,7 +85,6 @@
     self.config.testing_CrashAppOnLaunch = YES;
     self.config.testing_NoAppWillRun = NO;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
-    NSLog(@"%ld", (long)exitCode);
     XCTAssert(exitCode == BPExitStatusAppCrashed);
 
     self.config.testing_NoAppWillRun = YES;
@@ -98,7 +97,6 @@
     self.config.testing_NoAppWillRun = NO;
     self.config.stuckTimeout = @3;
     BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
-    NSLog(@"%ld", (long)exitCode);
     XCTAssert(exitCode == BPExitStatusTestTimeout);
 
     self.config.testing_NoAppWillRun = YES;

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -47,6 +47,7 @@
     self.config.jsonOutput = NO;
     self.config.headlessMode = NO;
     self.config.junitOutput = NO;
+    self.config.testing_NoAppWillRun = YES;
     NSString *path = @"testScheme.xcscheme";
     self.config.schemePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:path];
     [BPUtils quietMode:YES];
@@ -82,19 +83,25 @@
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testing_CrashAppOnLaunch = YES;
+    self.config.testing_NoAppWillRun = NO;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     NSLog(@"%ld", (long)exitCode);
     XCTAssert(exitCode == BPExitStatusAppCrashed);
-    
+
+    self.config.testing_NoAppWillRun = YES;
 }
 
 - (void)testAppThatHangsOnLaunch {
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBunldePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testing_HangAppOnLaunch = YES;
+    self.config.testing_NoAppWillRun = NO;
+    self.config.stuckTimeout = @3;
     BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
     NSLog(@"%ld", (long)exitCode);
-    //XCTAssert(exitCode == BPExitStatusAppHung);
+    XCTAssert(exitCode == BPExitStatusTestTimeout);
+
+    self.config.testing_NoAppWillRun = YES;
 }
 
 

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -207,7 +207,7 @@
 }
 
 - (void)testReportWithAppHangingTestsSet {
-    self.config.stuckTimeout = @5;
+    self.config.stuckTimeout = @2;
     self.config.plainOutput = YES;
     NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/BPStats.h
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/BPStats.h
@@ -36,9 +36,10 @@
 - (void)addTestFailure;
 - (void)addTestError;
 - (void)addSimulatorCrash;
+- (void)addApplicationCrash;
 - (void)addRetry;
 - (void)addTestRuntimeTimeout;
-- (void)addTestBPExitStatusTestTimeout;
+- (void)addTestOutputTimeout;
 - (void)addSimulatorCreateFailure;
 - (void)addSimulatorDeleteFailure;
 - (void)addSimulatorInstallFailure;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/BPStats.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/BPStats.m
@@ -24,7 +24,8 @@
 @property (nonatomic, assign) NSInteger testsTotal;
 @property (nonatomic, assign) NSInteger testFailures;
 @property (nonatomic, assign) NSInteger testErrors;
-@property (nonatomic, assign) NSInteger crashes;
+@property (nonatomic, assign) NSInteger simCrashes;
+@property (nonatomic, assign) NSInteger appCrashes;
 @property (nonatomic, assign) NSInteger retries;
 @property (nonatomic, assign) NSInteger runtimeTimeout;
 @property (nonatomic, assign) NSInteger outputTimeout;
@@ -133,7 +134,11 @@
 }
 
 - (void)addSimulatorCrash {
-    self.crashes++;
+    self.simCrashes++;
+}
+
+- (void)addApplicationCrash {
+    self.appCrashes++;
 }
 
 - (void)addRetry {
@@ -144,7 +149,7 @@
     self.runtimeTimeout++;
 }
 
-- (void)addTestBPExitStatusTestTimeout {
+- (void)addTestOutputTimeout {
     self.outputTimeout++;
 }
 
@@ -188,7 +193,8 @@
     [writer writeLine:@"Timeout due to test run-time:   %d", self.runtimeTimeout];
     [writer writeLine:@"Timeout due to no output:       %d", self.outputTimeout];
     [writer writeLine:@"Retries:                        %d", self.retries];
-    [writer writeLine:@"Simulator Crashes:              %d", self.crashes];
+    [writer writeLine:@"Application Crashes:            %d", self.appCrashes];
+    [writer writeLine:@"Simulator Crashes:              %d", self.simCrashes];
     [writer writeLine:@"Simulator Creation Failures:    %d", self.simulatorCreateFailures];
     [writer writeLine:@"Simulator Deletion Failures:    %d", self.simulatorDeleteFailures];
     [writer writeLine:@"App Install Failures:           %d", self.simulatorInstallFailures];

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -308,6 +308,20 @@ void onInterrupt(int ignore) {
         return;
     }
 
+    // This check should be last after all of the more specific tests
+    // It checks if the app is even running, which it must be at this point
+    // If it's not running and we passed the above checks (e.g., the tests are not yet completed)
+    // then it must mean the app has crashed.
+    // However, we have a short-circuit for tests because those may not actually run any app
+    if (!isRunning && context.pid > 0 && !self.config.testing_NoAppWillRun) {
+        // The tests ended before they even got started or the process is gone for some other reason
+        [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
+        [BPUtils printInfo:ERROR withString:@"Application crashed before tests started!"];
+        [[BPStats sharedStats] addApplicationCrash];
+        [self deleteSimulatorWithContext:context andStatus:BPExitStatusAppCrashed];
+        return;
+    }
+
     NEXT([self checkProcessWithContext:context]);
 }
 

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -326,6 +326,10 @@ void onInterrupt(int ignore) {
 }
 
 - (BOOL)isProcessRunningWithContext:(BPExecutionContext *)context {
+    if (self.config.testing_NoAppWillRun) {
+        return NO;
+    }
+    NSAssert(context.pid > 0, @"Application PID must be > 0");
     int rc = kill(context.pid, 0);
     return !(rc < 0);
 }

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -219,15 +219,12 @@ typedef NS_ENUM(NSInteger, SimulatorState) {
     // Timeout or crash on a test means we should skip it when we rerun the tests
     [self updateExecutedTestCaseList:testName inClass:testClass];
 
-    if (![[self.device stateString] isEqualToString:@"Shutdown"]) {
-        // self.appPID can be zero when running the parsing tests
-        // since we're not actually creating a simulator and running an app.
+    if (![[self.device stateString] isEqualToString:@"Shutdown"] && !self.config.testing_NoAppWillRun) {
         [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
-        if (self.appPID && (kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGTERM) < 0)) {
-            [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d", self.appPID];
-            perror("kill");
-        } else {
-            [BPUtils printInfo:ERROR withString:@"Success killing the process with appPID: %d", self.appPID];
+        NSAssert(self.appPID > 0, @"Failed to find a valid PID");
+        if ((kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGTERM) < 0)) {
+            [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d: %s",
+                self.appPID, strerror(errno)];
         }
     }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorRunner.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorRunner.m
@@ -242,6 +242,13 @@
                                                                                                                                  config:self.config]];
     [appLaunchEnvironment addEntriesFromDictionary:argsAndEnv[@"env"]];
 
+    if (self.config.testing_CrashAppOnLaunch) {
+        appLaunchEnvironment[@"_BP_TEST_CRASH_ON_LAUNCH"] = @"YES";
+    }
+    if (self.config.testing_HangAppOnLaunch) {
+        appLaunchEnvironment[@"_BP_TEST_HANG_ON_LAUNCH"] = @"YES";
+    }
+
     // Intercept stdout, stderr and post as simulator-output events
     NSString *stdout_stderr = [NSString stringWithFormat:@"%@/tmp/stdout_stderr_%@", self.device.dataPath, [[self.device UDID] UUIDString]];
     NSString *simStdoutPath = [BPUtils mkstemp:stdout_stderr withError:nil];

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -55,6 +55,7 @@
 // These fields are for testing.
 @property (nonatomic) BOOL testing_CrashAppOnLaunch;
 @property (nonatomic) BOOL testing_HangAppOnLaunch;
+@property (nonatomic) BOOL testing_NoAppWillRun;
 
 // Generated fields
 @property (nonatomic, strong) NSString *xcodePath;

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -20,6 +20,11 @@
 
 @interface BPConfiguration : NSObject <NSCopying>
 
+/*
+ * WARNING: Any fields you add here need to be explicitly handled in the copyWithZone
+ * and mutableCopyWithZone methods. Yeah, it's stupid, we should fix it.
+ */
+
 @property (nonatomic, strong) NSString *appBundlePath;
 @property (nonatomic, strong) NSString *testBundlePath;
 @property (nonatomic, strong) NSArray *additionalTestBundles;
@@ -46,6 +51,10 @@
 @property (nonatomic, strong) NSNumber *numSims;
 @property (nonatomic, strong) NSNumber *listTestsOnly;
 @property (nonatomic) BOOL quiet;
+
+// These fields are for testing.
+@property (nonatomic) BOOL testing_CrashAppOnLaunch;
+@property (nonatomic) BOOL testing_HangAppOnLaunch;
 
 // Generated fields
 @property (nonatomic, strong) NSString *xcodePath;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -250,6 +250,7 @@ struct BPOptions {
     newConfig.xcodePath = self.xcodePath;
     newConfig.testing_CrashAppOnLaunch = self.testing_CrashAppOnLaunch;
     newConfig.testing_HangAppOnLaunch = self.testing_HangAppOnLaunch;
+    newConfig.testing_NoAppWillRun = self.testing_NoAppWillRun;
 
     return newConfig;
 }

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -248,6 +248,8 @@ struct BPOptions {
     newConfig.simDeviceType = self.simDeviceType;
 #endif
     newConfig.xcodePath = self.xcodePath;
+    newConfig.testing_CrashAppOnLaunch = self.testing_CrashAppOnLaunch;
+    newConfig.testing_HangAppOnLaunch = self.testing_HangAppOnLaunch;
 
     return newConfig;
 }

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -25,6 +25,9 @@ bluepill_build()
 
 bluepill_test()
 {
+  # Dump our current diff state with master
+  git --no-pager log master..HEAD
+
   default_runtime=`grep BP_DEFAULT_RUNTIME ./Source/Shared/BPConstants.h | sed 's/.*BP_DEFAULT_RUNTIME *//;s/"//g;s/ *$//g;'`
   xcrun simctl list runtimes | grep -q "$default_runtime" || {
     echo "Your system doesn't contain latest runtime: iOS $default_runtime"


### PR DESCRIPTION
This incorporates the two tests that @ob added and includes fixes for detecting situations where the app fails to launch successfully, or we fail to detect that an app has frozen because the tests were not in the "Running" state. This also addresses an ask from @ob for a clearer message when the app crashes before tests have begun.
