### PR TITLE
(Closes #35) Make verbose mode default when listing tests.

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPApp.h
+++ b/Bluepill-runner/Bluepill-runner/BPApp.h
@@ -20,10 +20,9 @@
                   withExtraTestBundles:(NSArray *)extraTestBundles
                              withError:(NSError **)error;
 
-/*! @discussion Print the test bundles in the App (Basically the .xctest files inside the Plugins directory in the .app bundle)
- * @param verbose Print more information than just the name (e.g. list of tests inside the .xctest bundle file)
+/*! @discussion Print the test bundles in the App along with all of their test classes/cases (Basically the .xctest files inside the Plugins directory in the .app bundle)
  */
-- (void)listBundles:(BOOL)verbose;
+- (void)listTests;
 
 - (NSString *)testBundlePathForName:(NSString *)name;
 

--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -87,10 +87,10 @@
     return nil;
 }
 
-- (void)listBundles:(BOOL) verbose {
+- (void)listTests {
     for (BPXCTestFile *testFile in self.testBundles) {
         printf("%s.xctest\n", [testFile.name UTF8String]);
-        if (verbose) [testFile listTestClasses];
+        [testFile listTestClasses];
     }
 }
 

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -62,8 +62,8 @@ int main(int argc, char * argv[]) {
             exit(1);
         }
         if ([config.listTestsOnly integerValue] > 0) {
-            BOOL verbose = ([config.listTestsOnly integerValue] > 1) ? YES : NO;
-            [app listBundles: verbose];
+            BOOL verbose = [config.listTestsOnly integerValue] == 1;
+            [app listBundles:verbose];
             exit(0);
         }
 

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -61,9 +61,8 @@ int main(int argc, char * argv[]) {
             fprintf(stderr, "ERROR: %s\n", [[err localizedDescription] UTF8String]);
             exit(1);
         }
-        if ([config.listTestsOnly integerValue] > 0) {
-            BOOL verbose = [config.listTestsOnly integerValue] == 1;
-            [app listBundles:verbose];
+        if (config.listTestsOnly) {
+            [app listTests];
             exit(0);
         }
 

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -49,7 +49,7 @@
 @property (nonatomic, strong) NSString *outputDirectory;
 @property (nonatomic) BOOL headlessMode;
 @property (nonatomic, strong) NSNumber *numSims;
-@property (nonatomic, strong) NSNumber *listTestsOnly;
+@property (nonatomic) BOOL listTestsOnly;
 @property (nonatomic) BOOL quiet;
 
 // These fields are for testing.

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -86,7 +86,7 @@ struct BPOptions {
         "Print results in JUnit format."},
     {'F', "only-retry-failed", no_argument, "Off", BP_VALUE | BP_BOOL, "onlyRetryFailed",
         "If `failure-tolerance` is > 0, only retry tests that failed."},
-    {'l', "list-tests", no_argument, NULL, BP_VALUE, "listTestsOnly",
+    {'l', "list-tests", no_argument, NULL, BP_VALUE | BP_BOOL, "listTestsOnly",
         "Only list tests in bundle"},
 
     // options without short-options

--- a/Source/Shared/BPTestClass.m
+++ b/Source/Shared/BPTestClass.m
@@ -34,7 +34,7 @@
 
 - (void)listTestCases {
     for (BPTestCase *testCase in self.testCases) {
-        printf("    %s - %.2fs\n", [testCase.name UTF8String], [testCase.time floatValue]);
+        printf("  %s/%s\n", [self.name UTF8String], [testCase.name UTF8String]);
     }
 }
 

--- a/Source/Shared/BPXCTestFile.m
+++ b/Source/Shared/BPXCTestFile.m
@@ -100,7 +100,6 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
 
 - (void)listTestClasses {
     for (BPTestClass *testClass in self.testClasses) {
-        printf("  %s\n", [testClass.name UTF8String]);
         [testClass listTestCases];
     }
 }


### PR DESCRIPTION
Also changed test case output format to TestClassName/TestCaseName.