### PR TITLE
Fix UI test bundles being and array of array instead of array of xctFile

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -124,7 +124,7 @@
         [allTestBundles addObjectsFromArray:self.unitTestBundles];
     }
     if (self.uiTestBundles.count > 0) {
-        [allTestBundles addObject:self.uiTestBundles];
+        [allTestBundles addObjectsFromArray:self.uiTestBundles];
     }
     return allTestBundles;
 }


### PR DESCRIPTION
This PR is to the ui_test branch to fix an issue in that branch.  Corresponding issue is #16 

For the ui tests, the test bundles were being added as one array to allTestBundles instead of individual xctFiles.  This caused an exception in BPPacker where it was expecting a BPXCTestFile but instead had an array.