### PR TITLE
Correct required `test` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A full list supported options are listed here.
 |        `app`       |           -a           | The path to the host application to execute (your .app)                            |     Y    | n/a              |
 |    `output-dir`    |           -o           | Directory where to put output log files (bluepill only)                            |     Y    | n/a              |
 |    `scheme-path`   |           -s           | The scheme to run tests                                                            |     Y    | n/a              |
+|        test        |           -t           | The path to the test bundle to execute (single .xctest).                           |     Y    | n/a              |
 |       config       |           -c           | Read options from the specified configuration file instead of the command line     |     N    | n/a              |
 |       device       |           -d           | On which device to run the app.                                                    |     N    | iPhone 6         |
 |       exclude      |           -x           | Exclude a testcase in the set of tests to run  (takes priority over `include`).    |     N    | empty            |
@@ -74,7 +75,6 @@ A full list supported options are listed here.
 |       runtime      |           -r           | What runtime to use.                                                               |     N    | 10.2             |
 |    stuck-timeout   |           -S           | Timeout in seconds for a test that seems stuck (no output).                        |     N    | 300s             |
 |    test-timeout    |           -T           | Timeout in seconds for a test that is producing output.                            |     N    | 300s             |
-|        test        |           -t           | The path to the test bundle to execute (single .xctest).                           |     N    | n/a              |
 | additional-xctests |           n/a          | Additional XCTest bundles that is not Plugin folder                                |     N    | n/a              |
 |    repeat-count    |           -C           | Number of times we'll run the entire test suite (used for load testing).           |     N    | 1                |
 |      no-split      |           -N           | Test bundles you don't want to be packed into different groups to run in parallel. |     N    | n/a              |

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -39,6 +39,8 @@ struct BPOptions {
         "The path to the host application to execute (your .app)"},
     {'s', "scheme-path", BP_MASTER | BP_SLAVE, YES, NO, required_argument, NULL, BP_VALUE | BP_PATH, "schemePath",
         "The scheme to run tests."},
+    {'t', "test", BP_SLAVE, YES, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
+        "The path to the test bundle to execute (your .xctest)."},
 
     // Optional argument
     {'d', "device", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_DEVICE_TYPE, BP_VALUE, "deviceType",
@@ -67,8 +69,6 @@ struct BPOptions {
         "Directory where to put output log files (bluepill only)."},
     {'r', "runtime", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
         "What runtime to use."},
-    {'t', "test", BP_SLAVE, YES, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
-        "The path to the test bundle to execute (your .xctest)."},
     {'x', "exclude", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
         "Exclude a testcase in the set of tests to run (takes priority over `include`)."},
     {'X', "xcode-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "xcodePath",


### PR DESCRIPTION
- Move the `test` parameter to the required section in `BPOptions`
- Update the README to make the required nature of this flag obvious