### PR TITLE
error wasn't being dereferenced

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -53,7 +53,7 @@
         if (unitTestFiles) {
             [allUnitTestFiles addObjectsFromArray:unitTestFiles];
         }
-        if (error) {return nil;}
+        if (error && *error) {return nil;}
 
         // Read ui test bundles.
         if (config.testRunnerAppPath) {


### PR DESCRIPTION
This was introduced in the UI Test PR (#88) and was causing bluepill to exit with `ERROR: (null)`.