### PR TITLE
Add support for coverage data

### DIFF
--- a/Bluepill-cli/BPInstanceTests/SimulatorHelperTests.m
+++ b/Bluepill-cli/BPInstanceTests/SimulatorHelperTests.m
@@ -37,6 +37,7 @@
     config.appBundlePath = hostApplicationPath;
     NSString *hostBundleId = [SimulatorHelper bundleIdForPath:config.appBundlePath];
     config.xcodePath = @"/Applications/Xcode.app/Contents/Developer";
+    config.outputDirectory = @"/Users/test/output";
     NSDictionary *appLaunchEnvironment = [SimulatorHelper appLaunchEnvironmentWithBundleID:hostBundleId device:nil config:config];
     XCTAssert([appLaunchEnvironment[@"AppTargetLocation"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app"]);
     XCTAssert([appLaunchEnvironment[@"DYLD_FALLBACK_FRAMEWORK_PATH"] containsString:@"Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks"]);
@@ -47,6 +48,8 @@
     XCTAssert([appLaunchEnvironment[@"XCInjectBundle"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app/Plugins/BPSampleAppTests.xctest"]);
     XCTAssert([appLaunchEnvironment[@"XCInjectBundleInto"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app"]);
     XCTAssert([appLaunchEnvironment[@"XCTestConfigurationFilePath"] containsString:@"T/BPSampleAppTests-"]);
+    XCTAssertEqualObjects(appLaunchEnvironment[@"LLVM_PROFILE_FILE"], @"/Users/test/output/%p.profraw");
+    XCTAssertEqualObjects(appLaunchEnvironment[@"__XPC_LLVM_PROFILE_FILE"], @"/Users/test/output/%p.profraw");
 }
 
 @end

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -63,25 +63,34 @@
     NSString *hostAppExecPath = [SimulatorHelper executablePathforPath:config.appBundlePath];
     NSString *testSimulatorFrameworkPath = [[hostAppExecPath stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
     NSString *dyldLibraryPath = [NSString stringWithFormat:@"%@:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", testSimulatorFrameworkPath, config.xcodePath];
-    return @{
-             @"AppTargetLocation" : hostAppExecPath,
-             @"DYLD_FALLBACK_FRAMEWORK_PATH" : [NSString stringWithFormat:@"%@/Library/Frameworks:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath, config.xcodePath],
-             @"DTX_CONNECTION_SERVICES_PATH" : @"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Developer/Library/PrivateFrameworks/DTXConnectionServices.framework",
-             @"DYLD_FRAMEWORK_PATH" : dyldLibraryPath,
-             @"DYLD_INSERT_LIBRARIES" : [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection", config.xcodePath],
-             @"DYLD_LIBRARY_PATH" : dyldLibraryPath,
-             @"NSUnbufferedIO" : @YES,
-             @"OS_ACTIVITY_DT_MODE" : @YES,
-             @"TestBundleLocation" : config.testBundlePath,
-             @"XCInjectBundle" : config.testBundlePath,
-             @"XCInjectBundleInto" : hostAppExecPath,
-             @"MNTF_TINKER_DELAY": @0.01,
-             @"XCODE_DBG_XPC_EXCLUSIONS" : @"com.apple.dt.xctestSymbolicator",
-             @"XCTestConfigurationFilePath" : [SimulatorHelper testEnvironmentWithConfiguration:config],
-             @"__XCODE_BUILT_PRODUCTS_DIR_PATHS" : testSimulatorFrameworkPath,
-             @"__XPC_DYLD_FRAMEWORK_PATH" : testSimulatorFrameworkPath,
-             @"__XPC_DYLD_LIBRARY_PATH" : testSimulatorFrameworkPath,
-             };
+    NSMutableDictionary<NSString *, NSString *> *environment = [@{
+                                                                  @"AppTargetLocation" : hostAppExecPath,
+                                                                  @"DYLD_FALLBACK_FRAMEWORK_PATH" : [NSString stringWithFormat:@"%@/Library/Frameworks:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath, config.xcodePath],
+                                                                  @"DTX_CONNECTION_SERVICES_PATH" : @"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Developer/Library/PrivateFrameworks/DTXConnectionServices.framework",
+                                                                  @"DYLD_FRAMEWORK_PATH" : dyldLibraryPath,
+                                                                  @"DYLD_INSERT_LIBRARIES" : [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection", config.xcodePath],
+                                                                  @"DYLD_LIBRARY_PATH" : dyldLibraryPath,
+                                                                  @"NSUnbufferedIO" : @YES,
+                                                                  @"OS_ACTIVITY_DT_MODE" : @YES,
+                                                                  @"TestBundleLocation" : config.testBundlePath,
+                                                                  @"XCInjectBundle" : config.testBundlePath,
+                                                                  @"XCInjectBundleInto" : hostAppExecPath,
+                                                                  @"MNTF_TINKER_DELAY": @0.01,
+                                                                  @"XCODE_DBG_XPC_EXCLUSIONS" : @"com.apple.dt.xctestSymbolicator",
+                                                                  @"XCTestConfigurationFilePath" : [SimulatorHelper testEnvironmentWithConfiguration:config],
+                                                                  @"__XCODE_BUILT_PRODUCTS_DIR_PATHS" : testSimulatorFrameworkPath,
+                                                                  @"__XPC_DYLD_FRAMEWORK_PATH" : testSimulatorFrameworkPath,
+                                                                  @"__XPC_DYLD_LIBRARY_PATH" : testSimulatorFrameworkPath,
+                                                                  } mutableCopy];
+
+    if (config.outputDirectory) {
+        NSString *coveragePath = [config.outputDirectory stringByAppendingPathComponent:@"%p.profraw"];
+
+        environment[@"LLVM_PROFILE_FILE"] = coveragePath;
+        environment[@"__XPC_LLVM_PROFILE_FILE"] = coveragePath;
+    }
+
+    return environment;
 
 }
 


### PR DESCRIPTION
The environment variables to write coverage data weren't getting set. This meant the coverage data wasn't being written even if a target was built with code coverage enabled.

llvm-profdata needs to be called afterwards to merge the separate profraw files into a single coverage file:

`xcrun llvm-profdata merge -sparse output-dir/**/*.profraw -o Coverage.profdata`

(Thanks to https://github.com/plu/pxctest/issues/13 for the correct variables to set)