### PR TITLE
Fix for failtureTolerance (-f) option not working from the command line

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPCLITests.m
+++ b/Bluepill-cli/BPInstanceTests/BPCLITests.m
@@ -48,6 +48,9 @@
     [config saveOpt:[NSNumber numberWithInt:'a'] withArg:[BPTestHelper sampleAppPath]];
     [config saveOpt:[NSNumber numberWithInt:'s'] withArg:[BPTestHelper sampleTestScheme]];
     [config saveOpt:[NSNumber numberWithInt:'t'] withArg:[BPTestHelper sampleAppBalancingTestsBundlePath]];
+    [config saveOpt:[NSNumber numberWithInt:'R'] withArg:@"2"];
+    [config saveOpt:[NSNumber numberWithInt:'f'] withArg:@"1"];
+    [config saveOpt:[NSNumber numberWithInt:'n'] withArg:@"5"];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"foo"]];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"bar"]];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"baz"]];
@@ -59,6 +62,9 @@
     XCTAssert(result);
     NSArray *want = @[@"foo", @"bar", @"baz"];
     XCTAssert([config.noSplit isEqualToArray:want]);
+    XCTAssertEqualObjects(config.errorRetriesCount, @2);
+    XCTAssertEqualObjects(config.failureTolerance, @1);
+    XCTAssertEqualObjects(config.numSims, @5);
 }
 
 - (void)testIgnoringAdditionalTestBundles {

--- a/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
@@ -51,8 +51,8 @@
     XCTAssertNil(error);
     XCTAssert([config.appBundlePath isEqualToString:@"/Users/khu/Library/Developer/Xcode/DerivedData/voyager-frhgmrtfxqiflycndwcgfpqkbhdy/Build/Products/Debug-iphonesimulator/LinkedIn.app"]);
     XCTAssert([config.noSplit isEqualToArray:@[@"VoyagerTests"]]);
-    XCTAssert(config.repeatTestsCount.integerValue == 1);
-    XCTAssert(config.errorRetriesCount.integerValue == 0);
+    XCTAssertEqualObjects(config.repeatTestsCount, @1);
+    XCTAssertEqualObjects(config.errorRetriesCount, @0);
     XCTAssert([config.schemePath isEqualToString:@"/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme"]);
     XCTAssertEqual(config.headlessMode, NO);
     XCTAssert([config.outputDirectory isEqualToString:@"/Users/khu/tmp/simulator"]);

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -200,7 +200,7 @@
     self.config.outputDirectory = outputDir;
     self.config.junitOutput = YES;
     self.config.errorRetriesCount = @1;
-    self.config.failureTolerance = 1;
+    self.config.failureTolerance = @1;
     self.config.onlyRetryFailed = YES;
 
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
@@ -257,7 +257,7 @@
 - (void)testReportWithAppHangingTestsShouldReturnFailure {
     self.config.stuckTimeout = @3;
     self.config.plainOutput = YES;
-    self.config.failureTolerance = 0;
+    self.config.failureTolerance = @0;
     self.config.errorRetriesCount = @100;
     NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
@@ -298,7 +298,7 @@
     self.config.outputDirectory = outputDir;
     self.config.errorRetriesCount = @100;
     self.config.junitOutput = YES;
-    self.config.failureTolerance = 1;
+    self.config.failureTolerance = @1;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusTestsFailed);
     // validate the report
@@ -316,7 +316,7 @@
     self.config.outputDirectory = outputDir;
     self.config.errorRetriesCount = @100;
     self.config.junitOutput = YES;
-    self.config.failureTolerance = 1;
+    self.config.failureTolerance = @1;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusTestsFailed);
     // Make sure all tests started on the first run
@@ -341,7 +341,7 @@
     self.config.outputDirectory = outputDir;
     self.config.errorRetriesCount = @100;
     self.config.junitOutput = YES;
-    self.config.failureTolerance = 1;
+    self.config.failureTolerance = @1;
     self.config.onlyRetryFailed = YES;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusTestsFailed);

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -76,7 +76,7 @@ void onInterrupt(int ignore) {
     self.executionConfigCopy = [self.config copy];
 
     // Save our failure tolerance because we're going to be changing this
-    self.failureTolerance = self.executionConfigCopy.failureTolerance;
+    self.failureTolerance = [self.executionConfigCopy.failureTolerance integerValue];
 
     // Connect to test manager daemon and test bundle
 

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -37,7 +37,7 @@
     self.config.runtime = @BP_DEFAULT_RUNTIME;
     self.config.repeatTestsCount = @1;
     self.config.errorRetriesCount = @0;
-    self.config.failureTolerance = 0;
+    self.config.failureTolerance = @0;
     self.config.deviceType = @BP_DEFAULT_DEVICE_TYPE;
     self.config.plainOutput = NO;
     self.config.jsonOutput = NO;
@@ -72,7 +72,7 @@
 - (void)testTwoBPInstances {
     self.config.numSims = @2;
     self.config.errorRetriesCount = @2;
-    self.config.failureTolerance = 2;
+    self.config.failureTolerance = @2;
     //self.config.reuseSimulator = NO;
 
     NSError *err;
@@ -89,7 +89,7 @@
 - (void)testTwoBPInstancesWithUITests {
     self.config.numSims = @2;
     self.config.errorRetriesCount = @2;
-    self.config.failureTolerance = 2;
+    self.config.failureTolerance = @2;
     //self.config.reuseSimulator = NO;
 
     self.config.testBundlePath = [BPTestHelper sampleAppUITestBundlePath];

--- a/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
@@ -37,7 +37,7 @@
     self.config.runtime = @BP_DEFAULT_RUNTIME;
     self.config.repeatTestsCount = @1;
     self.config.errorRetriesCount = @0;
-    self.config.failureTolerance = 0;
+    self.config.failureTolerance = @0;
     self.config.deviceType = @BP_DEFAULT_DEVICE_TYPE;
     self.config.plainOutput = NO;
     self.config.jsonOutput = NO;

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic) BOOL junitOutput;
 @property (nonatomic) BOOL plainOutput;
 @property (nonatomic) BOOL jsonOutput;
-@property (nonatomic) NSUInteger failureTolerance;
+@property (nonatomic, strong) NSNumber *failureTolerance;
 @property (nonatomic) BOOL onlyRetryFailed;
 @property (nonatomic, strong) NSArray *testCasesToSkip;
 @property (nonatomic, strong) NSArray *testCasesToRun;


### PR DESCRIPTION
NSNumber options in BPConfiguration were getting set as NSStrings when set from the command line.
This was working for most options because intValue or integerValue works on both NSString and NSNumber.
Added a BP_INTEGER option type so that integers are explicitly converted to NSNumber.