### PR TITLE
Fix "PlugIns" directory can not be found on case-sensitive file system

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPTestHelper.m
+++ b/Bluepill-cli/BPInstanceTests/BPTestHelper.m
@@ -23,24 +23,24 @@
 
 // Return the path to the sample app's xctest with 1000 test cases
 + (NSString *)sampleAppBalancingTestsBundlePath {
-    return [[self sampleAppPath] stringByAppendingString:@"/Plugins/BPSampleAppTests.xctest"];
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppTests.xctest"];
 }
 
 // Return the path to the sample app's xctest with different kinds of negative tests
 + (NSString *)sampleAppNegativeTestsBundlePath {
-    return [[self sampleAppPath] stringByAppendingString:@"/Plugins/BPAppNegativeTests.xctest"];
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPAppNegativeTests.xctest"];
 }
 
 + (NSString *)sampleAppCrashingTestsBundlePath {
-    return [[self sampleAppPath] stringByAppendingString:@"/Plugins/BPSampleAppCrashingTests.xctest"];
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppCrashingTests.xctest"];
 }
 
 + (NSString *)sampleAppHangingTestsBundlePath {
-    return [[self sampleAppPath] stringByAppendingString:@"/Plugins/BPSampleAppHangingTests.xctest"];
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppHangingTests.xctest"];
 }
 
 + (NSString *)sampleAppFatalTestsBundlePath {
-    return [[self sampleAppPath] stringByAppendingString:@"/Plugins/BPSampleAppFatalErrorTests.xctest"];
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppFatalErrorTests.xctest"];
 }
 
 + (NSString *)resourceFolderPath {

--- a/Bluepill-cli/BPInstanceTests/SimulatorHelperTests.m
+++ b/Bluepill-cli/BPInstanceTests/SimulatorHelperTests.m
@@ -44,8 +44,8 @@
     XCTAssert([appLaunchEnvironment[@"DYLD_FRAMEWORK_PATH"] containsString:@"Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks"]);
     XCTAssert([appLaunchEnvironment[@"DYLD_INSERT_LIBRARIES"] containsString:@"Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection"]);
     XCTAssert([appLaunchEnvironment[@"DYLD_LIBRARY_PATH"] containsString:@"/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks"]);
-    XCTAssert([appLaunchEnvironment[@"TestBundleLocation"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app/Plugins/BPSampleAppTests.xctest"]);
-    XCTAssert([appLaunchEnvironment[@"XCInjectBundle"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app/Plugins/BPSampleAppTests.xctest"]);
+    XCTAssert([appLaunchEnvironment[@"TestBundleLocation"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app/PlugIns/BPSampleAppTests.xctest"]);
+    XCTAssert([appLaunchEnvironment[@"XCInjectBundle"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app/PlugIns/BPSampleAppTests.xctest"]);
     XCTAssert([appLaunchEnvironment[@"XCInjectBundleInto"] containsString:@"Build/Products/Debug-iphonesimulator/BPSampleApp.app"]);
     XCTAssert([appLaunchEnvironment[@"XCTestConfigurationFilePath"] containsString:@"T/BPSampleAppTests-"]);
     XCTAssertEqualObjects(appLaunchEnvironment[@"LLVM_PROFILE_FILE"], @"/Users/test/output/%p.profraw");

--- a/Bluepill-runner/Bluepill-runner/BPApp.h
+++ b/Bluepill-runner/Bluepill-runner/BPApp.h
@@ -13,7 +13,7 @@
 @interface BPApp : NSObject
 
 @property (nonatomic, strong) NSString *path;
-// All test bundles inside Plugins directory in app.
+// All test bundles inside PlugIns directory in app.
 @property (nonatomic, strong) NSArray *unitTestBundles;
 @property (nonatomic, strong) NSArray *uiTestBundles;
 @property (nonatomic, strong, getter=getAllTestBundles) NSArray *allTestBundles;
@@ -21,7 +21,7 @@
 + (instancetype)appWithConfig:(BPConfiguration *)config
                     withError:(NSError **)error;
 
-/*! @discussion Print the test bundles in the App along with all of their test classes/cases (Basically the .xctest files inside the Plugins directory in the .app bundle)
+/*! @discussion Print the test bundles in the App along with all of their test classes/cases (Basically the .xctest files inside the PlugIns directory in the .app bundle)
  */
 - (void)listTests;
 

--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -43,7 +43,7 @@
             [allUITestFiles addObject:testFile];
         }
     } else {
-        NSString *xcTestsPath = [hostAppPath stringByAppendingPathComponent:@"Plugins"];
+        NSString *xcTestsPath = [hostAppPath stringByAppendingPathComponent:@"PlugIns"];
         if (!([fm fileExistsAtPath:xcTestsPath isDirectory:&isdir]) && isdir) {
             NSLog(@"There is .xctest file under %@", xcTestsPath);
         }
@@ -58,7 +58,7 @@
 
         // Read ui test bundles.
         if (config.testRunnerAppPath) {
-            NSString *xcTestsPath = [config.testRunnerAppPath stringByAppendingPathComponent:@"Plugins"];
+            NSString *xcTestsPath = [config.testRunnerAppPath stringByAppendingPathComponent:@"PlugIns"];
             NSArray *uiTestFiles = [self testFilesFromDirectory:xcTestsPath isUITestBundle:YES withError:error];
             if (!([fm fileExistsAtPath:xcTestsPath isDirectory:&isdir]) && isdir) {
                 NSLog(@"There is .xctest file under %@", xcTestsPath);

--- a/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
@@ -157,7 +157,7 @@
 - (void)testNoSplittingOfExtraTestBundles {
     // Move the BPSampleAppTests.xctest out of the app so that we get just one.
     NSError *err;
-    NSString *inAppBundle = [self.config.appBundlePath stringByAppendingPathComponent:@"Plugins/BPSampleAppTests.xctest"];
+    NSString *inAppBundle = [self.config.appBundlePath stringByAppendingPathComponent:@"PlugIns/BPSampleAppTests.xctest"];
     NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"BPSampleAppTests.xctest"];
     if (![[NSFileManager defaultManager] moveItemAtPath:inAppBundle toPath:tmpPath error:&err]) {
         NSLog(@"%@", err);


### PR DESCRIPTION
This PR fixes that test bundle can't find on Mac OS Extended (Case-sensitive, Journaled) filesystem.

Xcode generate test bundles into "AppBundle/Plug<strong>I</strong>ns" after performing "Build for tests".
Original source is hard coded "Plugins"

