### PR TITLE
#118: Read environment variables for test action

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
@@ -54,7 +54,8 @@
                                                  @"MNTF_SCREENSHOTS_BASELINE_REAL" : @"/Documents/Baseline",
                                                  @"MNTF_SCREENSHOTS_DIFF" : @"$(PROJECT_DIR)/build/outputs/tests_artifacts/Diff",
                                                  @"MNTF_SCREENSHOTS_DIFF_REAL" : @"/Documents/Screenshots/Diff",
-                                                 @"MNTF_SCREENSHOTS_REAL" : @"/Documents/Screenshots"
+                                                 @"MNTF_SCREENSHOTS_REAL" : @"/Documents/Screenshots",
+                                                 @"TA_SCREENSHOTS_REAL" : @"/Documents/Screenshots"
                                                  }
                                          };
     XCTAssert([dictionary isEqualToDictionary:expectedDictionary], @"Dictionary doesn't match expectation");

--- a/Bluepill-cli/BPInstanceTests/Resource Files/testScheme.xcscheme
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/testScheme.xcscheme
@@ -86,6 +86,13 @@
                 ReferencedContainer = "container:mntf-ios.xcodeproj">
             </BuildableReference>
         </MacroExpansion>
+        <EnvironmentVariables>
+            <EnvironmentVariable
+                key = "TA_SCREENSHOTS_REAL"
+                value = "/Documents/Screenshots"
+                isEnabled = "YES">
+            </EnvironmentVariable>
+        </EnvironmentVariables>
         <AdditionalOptions>
         </AdditionalOptions>
     </TestAction>

--- a/Source/Shared/BPUtils.m
+++ b/Source/Shared/BPUtils.m
@@ -160,8 +160,9 @@ static BOOL quiet = NO;
         NSArray *argsNodes =
         [document nodesForXPath:[NSString stringWithFormat:@"//%@//CommandLineArgument", @"LaunchAction"] error:&error];
         NSAssert(error == nil, @"Failed to get nodes: %@", [error localizedFailureReason]);
-        NSArray *envNodes =
-        [document nodesForXPath:[NSString stringWithFormat:@"//%@//EnvironmentVariable", @"LaunchAction"] error:&error];
+        NSMutableArray *envNodes = [[NSMutableArray alloc] init];
+        [envNodes addObjectsFromArray:[document nodesForXPath:[NSString stringWithFormat:@"//%@//EnvironmentVariable", @"LaunchAction"] error:&error]];
+        [envNodes addObjectsFromArray:[document nodesForXPath:[NSString stringWithFormat:@"//%@//EnvironmentVariable", @"TestAction"] error:&error]];
         for (NSXMLElement *node in argsNodes) {
             NSString *argument = [[node attributeForName:@"argument"] stringValue];
             NSArray *argumentsArray = [argument componentsSeparatedByString:@" "];


### PR DESCRIPTION
#118 
This updates bluepill to read the test action env variables in addition to the launch action.  Updated the unit test to test this.

Should be reviewed if this would have negative impact on testing other than xctest.