### PR TITLE
Fix a bp hang when a test case just prints new lines

### DIFF
--- a/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
+++ b/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
@@ -26,8 +26,13 @@
     [super tearDown];
 }
 
+- (void)testAppHangingWithOutput {
+    while(TRUE){printf("\n");}
+}
+
 - (void)testAppHanging {
     while(TRUE){};
 }
+
 
 @end

--- a/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests1.xcscheme
+++ b/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests1.xcscheme
@@ -34,6 +34,104 @@
                ReferencedContainer = "container:Bluepill-cli.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+               BuildableName = "BPSampleApp.app"
+               BlueprintName = "BPSampleApp"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests2.xcscheme
+++ b/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests2.xcscheme
@@ -34,6 +34,104 @@
                ReferencedContainer = "container:Bluepill-cli.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+               BuildableName = "BPSampleApp.app"
+               BlueprintName = "BPSampleApp"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests3.xcscheme
+++ b/Bluepill-cli/Bluepill-cli.xcodeproj/xcshareddata/xcschemes/BPInstanceTests3.xcscheme
@@ -34,6 +34,104 @@
                ReferencedContainer = "container:Bluepill-cli.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+               BuildableName = "BPSampleApp.app"
+               BlueprintName = "BPSampleApp"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
@@ -108,10 +108,14 @@ static const NSString * const kPassed = @"passed";
 
 - (void)parseLine:(nullable NSString *)line {
     [BPUtils printInfo:DEBUGINFO withString:@"[OUTPUT] %@", line];
-    [self onOutputReceived:line];
+
     if (!line || ![line length]) {
         return;
     }
+
+    // We've seen hangs where the app just prints endless \n's so we
+    // don't count \n's as output.
+    [self onOutputReceived:line];
 
     NSRange lineRange = NSMakeRange(0, [line length]);
     BOOL logLine = YES;

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -154,6 +154,11 @@
         hostBundleId = [SimulatorHelper bundleIdForPath:hostAppPath];
         hostBundlePath = hostAppPath;
     }
+    if (!hostBundleId || !hostBundlePath) {
+        [BPUtils printInfo:ERROR withString:@"hostBundleId: %@ or hostBundlePath: %@ is null",
+         hostBundleId, hostBundlePath];
+        return NO;
+    }
 
     // Install the host application
     BOOL installed = [self.device

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -153,6 +153,9 @@
     NSDictionary *dic = [NSDictionary dictionaryWithContentsOfFile:[path stringByAppendingPathComponent:@"Info.plist"]];
 
     NSString *bundleId = [dic objectForKey:(NSString *)kCFBundleIdentifierKey];
+    if (!bundleId) {
+        [BPUtils printInfo:ERROR withString:@"Could not extract bundleID: %@", dic];
+    }
     return bundleId;
 }
 

--- a/Bluepill-runner/Bluepill.xcodeproj/xcshareddata/xcschemes/BPIntegrationTests.xcscheme
+++ b/Bluepill-runner/Bluepill.xcodeproj/xcshareddata/xcschemes/BPIntegrationTests.xcscheme
@@ -20,6 +20,104 @@
                ReferencedContainer = "container:Bluepill.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+               BuildableName = "BPSampleApp.app"
+               BlueprintName = "BPSampleApp"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:../BPSampleApp/BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
We've seen certain cases (root cause undetermined) where a test case will hang while only printing new lines (sometimes millions of them). 

While the test case might be the culprit, it seems easy enough to not count empty new lines as output in bluepill and treat this kind of busy-hanging as a test hanging.