### PR TITLE
Better fix for app hanging by printing a bunch of new lines

### DIFF
--- a/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
+++ b/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
@@ -26,13 +26,8 @@
     [super tearDown];
 }
 
-- (void)testAppHangingWithOutput {
-    while(TRUE){printf("\n");}
-}
-
 - (void)testAppHanging {
     while(TRUE){};
 }
-
 
 @end

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
@@ -93,6 +93,15 @@ static const NSString * const kPassed = @"passed";
 - (void)handleChunkData:(nonnull NSData *)chunk {
     if ([chunk length] > 0) {
         NSString *str = [[NSString alloc] initWithData:chunk encoding:NSUTF8StringEncoding];
+        if (!str) {
+            [BPUtils printInfo:WARNING withString:@"Failed to UTF8 decode chunk: %@", chunk];
+            str = [[NSString alloc] initWithData:chunk encoding:NSASCIIStringEncoding];
+            [BPUtils printInfo:WARNING withString:@"ASCII: %@", str];
+        }
+        if (!str) {
+            [BPUtils printInfo:ERROR withString:@"Failed to ASCII decode chunk: %@", chunk];
+            exit(1);
+        }
         NSRange range = [str rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
         unsigned long numLines = 0;
         unsigned long maxLines = [chunk length];
@@ -101,9 +110,9 @@ static const NSString * const kPassed = @"passed";
             [self.log writeLine:@"%@", self.line];
             [self parseLine:self.line];
             if (numLines++ > maxLines) {
-                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%@, %@}, %d, %@",
+                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%d, %d}, %d, %@",
                  range.length, range.location, [chunk length], str];
-                [BPUtils printInfo:ERROR withString:@"Data: %@", [[NSString alloc] initWithData:chunk encoding:NSUTF8StringEncoding]];
+                [BPUtils printInfo:ERROR withString:@"Data: %@", chunk];
                 // Fail hard.
                 exit(1);
             }

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
@@ -108,14 +108,10 @@ static const NSString * const kPassed = @"passed";
 
 - (void)parseLine:(nullable NSString *)line {
     [BPUtils printInfo:DEBUGINFO withString:@"[OUTPUT] %@", line];
-
+    [self onOutputReceived:line];
     if (!line || ![line length]) {
         return;
     }
-
-    // We've seen hangs where the app just prints endless \n's so we
-    // don't count \n's as output.
-    [self onOutputReceived:line];
 
     NSRange lineRange = NSMakeRange(0, [line length]);
     BOOL logLine = YES;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
@@ -94,10 +94,19 @@ static const NSString * const kPassed = @"passed";
     if ([chunk length] > 0) {
         NSString *str = [[NSString alloc] initWithData:chunk encoding:NSUTF8StringEncoding];
         NSRange range = [str rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
+        unsigned long numLines = 0;
+        unsigned long maxLines = [chunk length];
         while (range.location != NSNotFound) {
             self.line = [self.line stringByAppendingString:[str substringToIndex:range.location] ?: @""];
             [self.log writeLine:@"%@", self.line];
             [self parseLine:self.line];
+            if (numLines++ > maxLines) {
+                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%@, %@}, %d, %@",
+                 range.length, range.location, [chunk length], str];
+                [BPUtils printInfo:ERROR withString:@"Data: %@", [[NSString alloc] initWithData:chunk encoding:NSUTF8StringEncoding]];
+                // Fail hard.
+                exit(1);
+            }
             self.line = @"";
             str = [str substringFromIndex:range.location+range.length];
             range = [str rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];


### PR DESCRIPTION
A more careful examination illustrated that the problem wasn't with a test that loops indefinitely. It turns out that we weren't error checking the UTF-8 decoding of the buffer and if the data happened to be cut in the middle of a UTF-8 char, you'd get an error decoding it and the loop would never finish.

This isn't the Right Fix(tm), but it's better than what's in there... the right fix would be to read the data in chunks without interpreting anything until we get to the `\n`, then convert the full line to an NSstring and move the remaining data to another buffer. 

We're pushing this out though because it's a quick workaround for a serious bug.