### PR TITLE
Fix balancing of tests to run after excluding skipped tests

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -41,6 +41,9 @@
             if (testCasesToRun) {
                 [bundleTestsToRun intersectSet:[[NSSet alloc] initWithArray:testCasesToRun]];
             }
+            if (config.testCasesToSkip) {
+                [bundleTestsToRun minusSet:[[NSSet alloc] initWithArray:config.testCasesToSkip]];
+            }
             if (bundleTestsToRun.count > 0) {
                 testsToRunByTestFilePath[xctFile.path] = bundleTestsToRun;
                 totalTests += bundleTestsToRun.count;
@@ -74,7 +77,6 @@
             range.length = min(testsPerGroup, bundleTestsToRun.count - packed);
             NSMutableArray *testsToSkip = [NSMutableArray arrayWithArray:allTestCases];
             [testsToSkip removeObjectsInArray:[bundleTestsToRun subarrayWithRange:range]];
-            [testsToSkip addObjectsFromArray:config.testCasesToSkip]; // always add the tests to skip.
             [bundles addObject:[[BPBundle alloc] initWithPath:xctFile.path isUITestBundle:xctFile.isUITestFile andTestsToSkip:testsToSkip]];
             packed += range.length;
         }

--- a/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
@@ -66,6 +66,28 @@
 
 }
 
+- (void)testPackingProvidesBalancedBundles {
+    self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
+    self.config.numSims = @8;
+    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    NSMutableArray *testCasesToSkip = [NSMutableArray new];
+    for (BPXCTestFile *xctFile in app.allTestBundles) {
+        [testCasesToSkip addObjectsFromArray:xctFile.allTestCases];
+    }
+    for (long i = 1; i <= 8; i++) {
+        [testCasesToSkip removeObject:[NSString stringWithFormat:@"BPSampleAppTests/testCase%03ld", i]];
+    }
+    self.config.testCasesToSkip = testCasesToSkip;
+    XCTAssert(app != nil);
+    NSArray<BPBundle *> *bundles;
+    bundles = [BPPacker packTests:app.allTestBundles configuration:self.config andError:nil];
+    for (long i = 1; i <= 8; i++) {
+        BPBundle *bpBundle = bundles[i - 1];
+        NSString *testThatShouldExist = [NSString stringWithFormat:@"BPSampleAppTests/testCase%03ld", i];
+        XCTAssertFalse([bpBundle.testsToSkip containsObject:testThatShouldExist]);
+    }
+}
+
 - (void)testPacking {
     NSArray *want, *got;
     NSArray *allTests;


### PR DESCRIPTION
This fixes an issue where all non-skipped tests are run on the one simulator by balancing the desired tests between different simulators. Before, only one bundle got the desired tests if the number of skipped tests was large.

Issue: https://github.com/linkedin/bluepill/issues/145