### PR TITLE
Fix issue where included test suites were not being expanded out

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -106,7 +106,6 @@
 + (BPConfiguration *)normalizeBPConfiguration:(BPConfiguration *)config
                                 withTestFiles:(NSArray *)xcTestFiles {
     
-    config = [config mutableCopy];
     NSMutableSet *testsToRun = [NSMutableSet new];
     NSMutableSet *testsToSkip = [NSMutableSet new];
     for (BPXCTestFile *xctFile in xcTestFiles) {

--- a/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPRunnerTests.m
@@ -30,7 +30,6 @@
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
     self.config = [BPConfiguration new];
-    self.config.program = BP_MASTER;
     self.config.testBundlePath = testBundlePath;
     self.config.appBundlePath = hostApplicationPath;
     self.config.stuckTimeout = @30;
@@ -165,6 +164,8 @@
         XCTAssertTrue([bundleTestsToSkip isSubsetOfSet:expectedTestCasesToRun]);
         XCTAssertFalse([expectedTestCasesToRun isSubsetOfSet:bundleTestsToSkip]);
     }
+    NSSet *configTestCasesToRun = [NSSet setWithArray:self.config.testCasesToRun];
+    XCTAssertTrue([expectedTestCasesToRun isEqualToSet:configTestCasesToRun]);
 }
 
 - (void)testPackingNoTestsWhenIncludedTestSuiteHasSimilarButNonexistentPrefix {


### PR DESCRIPTION
Fixes Issue #149 by _not_ making a mutable copy and updating the configuration itself to expand out the testsuite into it's individual tests.