### PR TITLE
Support skipped tests from scheme file

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
@@ -74,4 +74,19 @@
     XCTAssert([config.outputDirectory containsString:@"./simulator"]);
 }
 
+- (void)testConfigLoadsExcludedTestsFromScheme {
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    NSError *error;
+    NSString *resourcePath = [BPTestHelper resourceFolderPath];
+    NSString *configFile = [resourcePath stringByAppendingPathComponent:@"testConfigLoadsExcludedTestsFromScheme.json"];
+    [config loadConfigFile:configFile withError:&error];
+    XCTAssertNil(error);
+    config.schemePath = [resourcePath stringByAppendingPathComponent:@"BPSaskatoon.xcscheme"];
+    [config processOptionsWithError:&error];
+    XCTAssertNil(error);
+    XCTAssert([config.testCasesToSkip containsObject:@"BPAppNegativeTests"]);
+    XCTAssert([config.testCasesToSkip containsObject:@"BPSampleAppCrashingTests/testAppCrash1"]);
+    XCTAssert([config.testCasesToSkip containsObject:@"BPSampleAppCrashingTests/testAppCrash2"]);
+}
+
 @end

--- a/Bluepill-cli/BPInstanceTests/Resource Files/BPSaskatoon.xcscheme
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/BPSaskatoon.xcscheme
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+               BuildableName = "BPSampleApp.app"
+               BlueprintName = "BPSampleApp"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F461DB5D45E00867756"
+               BuildableName = "BPSampleAppTests.xctest"
+               BlueprintName = "BPSampleAppTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB24F591DB5D83C00867756"
+               BuildableName = "BPAppNegativeTests.xctest"
+               BlueprintName = "BPAppNegativeTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BPAppNegativeTests">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAA4DA361DC3C02A00A58BCC"
+               BuildableName = "BPSampleAppCrashingTests.xctest"
+               BlueprintName = "BPSampleAppCrashingTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "BPSampleAppCrashingTests/testAppCrash1">
+               </Test>
+               <Test
+                  Identifier = "BPSampleAppCrashingTests/testAppCrash2">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA9C2DD11DD7F182007CB967"
+               BuildableName = "BPSampleAppFatalErrorTests.xctest"
+               BlueprintName = "BPSampleAppFatalErrorTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA4BCFC51DC47EC700592FA4"
+               BuildableName = "BPSampleAppHangingTests.xctest"
+               BlueprintName = "BPSampleAppHangingTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
+               BuildableName = "BPSampleAppUITests.xctest"
+               BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+            BuildableName = "BPSampleApp.app"
+            BlueprintName = "BPSampleApp"
+            ReferencedContainer = "container:BPSampleApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+            BuildableName = "BPSampleApp.app"
+            BlueprintName = "BPSampleApp"
+            ReferencedContainer = "container:BPSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAB24F2D1DB5D45E00867756"
+            BuildableName = "BPSampleApp.app"
+            BlueprintName = "BPSampleApp"
+            ReferencedContainer = "container:BPSampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Bluepill-cli/BPInstanceTests/Resource Files/testConfigLoadsExcludedTestsFromScheme.json
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/testConfigLoadsExcludedTestsFromScheme.json
@@ -1,0 +1,9 @@
+{
+    "app": "/Users/khu/Library/Developer/Xcode/DerivedData/voyager-frhgmrtfxqiflycndwcgfpqkbhdy/Build/Products/Debug-iphonesimulator/LinkedIn.app",
+    "error-retries": 0,
+    "scheme-path": "/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme",
+    "repeat-count": 1,
+    "test-bundle-path": "/usr/bin",
+    "output-dir": "/Users/khu/tmp/simulator",
+    "headless": false
+}

--- a/Bluepill-cli/Bluepill-cli.xcodeproj/project.pbxproj
+++ b/Bluepill-cli/Bluepill-cli.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		261070761EDA4AFC00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json in Resources */ = {isa = PBXBuildFile; fileRef = 261070751EDA4AFC00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */; };
+		261070781EDA4B0A00E1DC1C /* BPSaskatoon.xcscheme in Resources */ = {isa = PBXBuildFile; fileRef = 261070771EDA4B0A00E1DC1C /* BPSaskatoon.xcscheme */; };
 		7A202A411DB0066100D935E3 /* BPWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A202A401DB0066100D935E3 /* BPWriter.m */; };
 		7A4933151DAD63A50060D54F /* SimulatorMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4933141DAD63A50060D54F /* SimulatorMonitor.m */; };
 		7A4D7A811DDA5FA1001E085D /* BPTreeParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4D7A801DDA5FA1001E085D /* BPTreeParserTests.m */; };
@@ -101,6 +103,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		261070751EDA4AFC00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = testConfigLoadsExcludedTestsFromScheme.json; path = "BPInstanceTests/Resource Files/testConfigLoadsExcludedTestsFromScheme.json"; sourceTree = "<group>"; };
+		261070771EDA4B0A00E1DC1C /* BPSaskatoon.xcscheme */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = BPSaskatoon.xcscheme; path = "BPInstanceTests/Resource Files/BPSaskatoon.xcscheme"; sourceTree = "<group>"; };
 		7A202A3D1DAED04900D935E3 /* BPExitStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPExitStatus.h; sourceTree = "<group>"; };
 		7A202A3F1DB0066100D935E3 /* BPWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPWriter.h; sourceTree = "<group>"; };
 		7A202A401DB0066100D935E3 /* BPWriter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPWriter.m; sourceTree = "<group>"; };
@@ -962,6 +966,8 @@
 		7A7901791D5CB679004D4325 = {
 			isa = PBXGroup;
 			children = (
+				261070771EDA4B0A00E1DC1C /* BPSaskatoon.xcscheme */,
+				261070751EDA4AFC00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */,
 				7A7901841D5CB679004D4325 /* Bluepill-cli */,
 				7A7901851D5CB679004D4325 /* main.m */,
 				BAB24F691DB5DB2300867756 /* BPInstanceTests */,
@@ -1984,6 +1990,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				261070781EDA4B0A00E1DC1C /* BPSaskatoon.xcscheme in Resources */,
+				261070761EDA4AFC00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json in Resources */,
 				C4FAC2951E5E67ED00ACC5D9 /* testConfig-busted.json in Resources */,
 				BA180A141DBB088100D7D130 /* testScheme.xcscheme in Resources */,
 				BA0C554D1DDAE241009E1377 /* failure_retry_report.xml in Resources */,

--- a/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
+++ b/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		261070731EDA494F00E1DC1C /* BPSaskatoon.xcscheme in Resources */ = {isa = PBXBuildFile; fileRef = 261070711EDA494F00E1DC1C /* BPSaskatoon.xcscheme */; };
+		261070741EDA494F00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json in Resources */ = {isa = PBXBuildFile; fileRef = 261070721EDA494F00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */; };
 		56B74BCA1E4C0A15004E6624 /* BPIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 56B74BC91E4C0A15004E6624 /* BPIntegrationTests.m */; };
 		7A4FB8CB1DF89A370073F268 /* BPXCTestFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FB8CA1DF89A370073F268 /* BPXCTestFile.m */; };
 		7A4FB8DD1DF89B1A0073F268 /* BPTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FB8DA1DF89B1A0073F268 /* BPTestCase.m */; };
@@ -56,6 +58,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		261070711EDA494F00E1DC1C /* BPSaskatoon.xcscheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = BPSaskatoon.xcscheme; path = "../../../Bluepill-cli/BPInstanceTests/Resource Files/BPSaskatoon.xcscheme"; sourceTree = "<group>"; };
+		261070721EDA494F00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = testConfigLoadsExcludedTestsFromScheme.json; path = "../../../Bluepill-cli/BPInstanceTests/Resource Files/testConfigLoadsExcludedTestsFromScheme.json"; sourceTree = "<group>"; };
 		56B74BC91E4C0A15004E6624 /* BPIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPIntegrationTests.m; sourceTree = "<group>"; };
 		7A4FB8C91DF89A370073F268 /* BPXCTestFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPXCTestFile.h; sourceTree = "<group>"; };
 		7A4FB8CA1DF89A370073F268 /* BPXCTestFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPXCTestFile.m; sourceTree = "<group>"; };
@@ -180,6 +184,8 @@
 		BA9C2DAD1DD674AD007CB967 /* Resource Files */ = {
 			isa = PBXGroup;
 			children = (
+				261070711EDA494F00E1DC1C /* BPSaskatoon.xcscheme */,
+				261070721EDA494F00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json */,
 				BA9C2DB01DD67B66007CB967 /* testScheme.xcscheme */,
 				BA9C2DAE1DD674AD007CB967 /* BPSampleAppTests.xctest */,
 			);
@@ -321,8 +327,10 @@
 				BA9C2DB11DD67B66007CB967 /* testScheme.xcscheme in Resources */,
 				BA70318A1DE4ED2F008B3539 /* result3.xml in Resources */,
 				BA7031881DE4ED2F008B3539 /* result1.xml in Resources */,
+				261070731EDA494F00E1DC1C /* BPSaskatoon.xcscheme in Resources */,
 				BA9C2DAF1DD674AD007CB967 /* BPSampleAppTests.xctest in Resources */,
 				BA7031891DE4ED2F008B3539 /* result2.xml in Resources */,
+				261070741EDA494F00E1DC1C /* testConfigLoadsExcludedTestsFromScheme.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Addresses issue #109 by adding support to read tests to exclude from the skipped tests in a given scheme.