### PR TITLE
Move the code that appends commandLineArguments to bp

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -256,6 +256,13 @@
             }
         }
     }
+
+    // These are appended by Xcode so we do that here.
+    [commandLineArgs addObjectsFromArray:@[
+                                           @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                           @"-ApplePersistenceIgnoreState", @"YES"
+                                           ]];
+
     argsAndEnv[@"args"] = [commandLineArgs copy];
     argsAndEnv[@"env"] = self.config.environmentVariables ?: @{};
     NSMutableDictionary *appLaunchEnvironment = [NSMutableDictionary dictionaryWithDictionary:[SimulatorHelper appLaunchEnvironmentWithBundleID:hostBundleId device:self.device config:self.config]];

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -571,11 +571,6 @@ static NSUUID *sessionID;
             }
         }
         
-        [commandLineArgs addObjectsFromArray:@[
-                                               @"-NSTreatUnknownArgumentsAsOpen", @"NO",
-                                               @"-ApplePersistenceIgnoreState", @"YES"
-                                               ]];
-        
         for (NSXMLElement *node in envNodes) {
             NSString *key = [[node attributeForName:@"key"] stringValue];
             NSString *value = [[node attributeForName:@"value"] stringValue];


### PR DESCRIPTION
We were doing this fix in the parsing of config files stage, but this seems to be needed
for every run of the app so it fits better in the launchApp stage.

I think this is needed because of what I found while investigating #179 (namely [this](https://github.com/linkedin/bluepill/issues/179#issuecomment-314189528)).