### PR TITLE
Add argument 'test-failure-retries' to support test failures retry

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPCLITests.m
+++ b/Bluepill-cli/BPInstanceTests/BPCLITests.m
@@ -50,6 +50,7 @@
     [config saveOpt:[NSNumber numberWithInt:'R'] withArg:@"2"];
     [config saveOpt:[NSNumber numberWithInt:'f'] withArg:@"1"];
     [config saveOpt:[NSNumber numberWithInt:'n'] withArg:@"5"];
+    [config saveOpt:[NSNumber numberWithInt:'B'] withArg:@"3"];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"foo"]];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"bar"]];
     [config saveOpt:[NSNumber numberWithInt:'N'] withArg:[NSString stringWithUTF8String:"baz"]];
@@ -63,6 +64,7 @@
     XCTAssert([config.noSplit isEqualToArray:want]);
     XCTAssertEqualObjects(config.errorRetriesCount, @2);
     XCTAssertEqualObjects(config.failureTolerance, @1);
+    XCTAssertEqualObjects(config.testFailureRetriesCount, @3);
     XCTAssertEqualObjects(config.numSims, @5);
 }
 

--- a/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
@@ -54,6 +54,7 @@
     XCTAssert([config.noSplit isEqualToArray:@[@"VoyagerTests"]]);
     XCTAssertEqualObjects(config.repeatTestsCount, @1);
     XCTAssertEqualObjects(config.errorRetriesCount, @0);
+    XCTAssertEqualObjects(config.testFailureRetriesCount, @2);
     XCTAssert([config.schemePath isEqualToString:@"/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme"]);
     XCTAssertEqual(config.headlessMode, NO);
     XCTAssert([config.outputDirectory isEqualToString:@"/Users/khu/tmp/simulator"]);

--- a/Bluepill-cli/BPInstanceTests/Resource Files/testConfig.json
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/testConfig.json
@@ -6,6 +6,7 @@
     "error-retries": 0,
     "scheme-path": "/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme",
     "repeat-count": 1,
+    "test-failure-retries": 2,
     "output-dir": "/Users/khu/tmp/simulator",
     "headless": false
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A full list supported options are listed here.
 |      plain-output      |           -p           | Print results in plain text.                                                       |     N    | true             |
 |      printf-config     |           -P           | Print a configuration file suitable for passing back using the `-c` option.        |     N    | n/a              |
 |      error-retries     |           -R           | Number of times we'll recover from app crashing/hanging and continue running       |     N    | 5                |
+|  test-failure-retries  |           -B           | Number of times to retry test case failures. It requires `failure-tolerance` >0       |     N    | 0                |
 |    failure-tolerance   |           -f           | The number of retries on any failures (app crash/test failure)                     |     N    | 0                |
 |    only-retry-failed   |           -F           | When `failure-tolerance` > 0, only retry tests that failed                         |     N    | false            |
 |         runtime        |           -r           | What runtime to use.                                                               |     N    | iOS 10.3        |

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSMutableArray *bpCmdLineArgs; // command line arguments passed to bluepill
 @property (nonatomic, strong) NSNumber *repeatTestsCount;
 @property (nonatomic, strong) NSNumber *errorRetriesCount;
+@property (nonatomic, strong) NSNumber *testFailureRetriesCount;
 @property (nonatomic, strong) NSNumber *stuckTimeout;
 @property (nonatomic, strong) NSNumber *testCaseTimeout;
 @property (nonatomic, strong) NSArray *noSplit;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -62,6 +62,8 @@ struct BPOptions {
         "Print a configuration file suitable for passing back using the `-c` option."},
     {'R', "error-retries", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "4", BP_VALUE | BP_INTEGER, "errorRetriesCount",
         "Number of times we'll recover from crashes to continue running the current test suite."},
+    {'B', "test-failure-retries", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "0", BP_VALUE | BP_INTEGER, "testFailureRetriesCount",
+        "Number of times to retry test case failures. It requires `failure-tolerance` > 0"},
     {'S', "stuck-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "stuckTimeout",
         "Timeout in seconds for a test that seems stuck (no output)."},
     {'T', "test-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "testCaseTimeout",


### PR DESCRIPTION
Now we have 3 retry number
error-retries: the retry number to recover from  app crashing/hanging
test-failure-retries: the retry number on test case failures. 
failure-tolerance: The outer loop retry for both error-retries and test-failure-retries

We don't have 'test-failure-retries' before. So if we set failure-tolerance > 0, then it will retry on both error(crash/hang) and test case failure. With this change, user can decide rerun either one. One typical use case is that DON'T retry test failure which caused by test flakiness, but retry the crash or hanging which is tools/environment issue.

We always can select rerun ALL test or FAILED test via 'only-retry-failed' 



