### PR TITLE
Recover from scratch if there is tooling failure

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -142,12 +142,46 @@ void onInterrupt(int ignore) {
     self.retries += 1;
 
     // Log some useful information to the log
-    [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
+    [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.context.exitStatus]];
     [BPUtils printInfo:INFO withString:@"Failure Tolerance: %lu", self.failureTolerance];
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
 
     // Then start again at the beginning
+    [BPUtils printInfo:INFO withString:@"Start to retry"];
     NEXT([self begin]);
+}
+
+// Recover from scratch if there is tooling failure, such as
+//  - BPExitStatusSimulatorCreationFailed
+//  - BPExitStatusSimulatorCrashed
+//  - BPExitStatusInstallAppFailed
+//  - BPExitStatusUninstallAppFailed
+//  - BPExitStatusLaunchAppFailed
+- (void)recover {
+  // If error retry reach to the max, then return
+  if (self.retries == [self.config.errorRetriesCount integerValue]) {
+      self.finalExitStatus = self.context.exitStatus | self.context.finalExitStatus;
+      self.exitLoop = YES;
+      [BPUtils printInfo:ERROR withString:@"Too many retries have occurred. Giving up."];
+      return;
+  }
+
+  [self.context.parser cleanup];
+  // If we're not retrying only failed tests, we need to get rid of our saved tests, so that we re-execute everything. Recopy config.
+  if (self.executionConfigCopy.onlyRetryFailed == NO) {
+      self.executionConfigCopy = [self.config copy];
+  }
+  // Increment the retry count
+  self.retries += 1;
+
+  // Log some useful information to the log
+  [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.context.exitStatus]];
+  [BPUtils printInfo:INFO withString:@"Failure Tolerance: %lu", self.failureTolerance];
+  [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
+
+  // Then start again from the beginning
+  [BPUtils printInfo:INFO withString:@"Start to recover"];
+  NEXT([self begin]);
 }
 
 // Proceed to next test case
@@ -159,11 +193,12 @@ void onInterrupt(int ignore) {
         return;
     }
     self.retries += 1;
-    [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
+    [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.context.exitStatus]];
     [BPUtils printInfo:INFO withString:@"Failure Tolerance: %lu", self.failureTolerance];
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
     self.context.attemptNumber = self.retries + 1; // set the attempt number
     self.context.exitStatus = BPExitStatusTestsAllPassed; // reset exitStatus
+    [BPUtils printInfo:INFO withString:@"Start to proceed"];
     NEXT([self beginWithContext:self.context]);
 }
 
@@ -579,7 +614,7 @@ void onInterrupt(int ignore) {
 // Only called when bp is running in the delete only mode.
 - (void)deleteSimulatorOnlyTaskWithContext:(BPExecutionContext *)context {
     
-    if ([context.runner useSimulatorWithDeviceUDID: [[NSUUID alloc] initWithUUIDString:context.config.deleteSimUDID]]) {        
+    if ([context.runner useSimulatorWithDeviceUDID: [[NSUUID alloc] initWithUUIDString:context.config.deleteSimUDID]]) {
         NEXT([self deleteSimulatorWithContext:context andStatus:BPExitStatusSimulatorDeleted]);
     } else {
         [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to reconnect to simulator %@", context.config.deleteSimUDID]];
@@ -627,13 +662,13 @@ void onInterrupt(int ignore) {
             }
             return;
 
-        // Retry from scratch if there is tooling failure.
+        // Recover from scratch if there is tooling failure.
         case BPExitStatusSimulatorCreationFailed:
         case BPExitStatusSimulatorCrashed:
         case BPExitStatusInstallAppFailed:
         case BPExitStatusUninstallAppFailed:
         case BPExitStatusLaunchAppFailed:
-            NEXT([self retry]);
+            NEXT([self recover]);
             return;
 
         // If it is test hanging or crashing, we set final exit code of current context and proceed.

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -147,7 +147,7 @@ void onInterrupt(int ignore) {
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
 
     // Then start again at the beginning
-    [BPUtils printInfo:INFO withString:@"Start to retry"];
+    [BPUtils printInfo:INFO withString:@"Retrying from scratch"];
     NEXT([self begin]);
 }
 
@@ -180,7 +180,7 @@ void onInterrupt(int ignore) {
   [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
 
   // Then start again from the beginning
-  [BPUtils printInfo:INFO withString:@"Start to recover"];
+  [BPUtils printInfo:INFO withString:@"Recovering from tooling problem"];
   NEXT([self begin]);
 }
 
@@ -198,7 +198,7 @@ void onInterrupt(int ignore) {
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
     self.context.attemptNumber = self.retries + 1; // set the attempt number
     self.context.exitStatus = BPExitStatusTestsAllPassed; // reset exitStatus
-    [BPUtils printInfo:INFO withString:@"Start to proceed"];
+    [BPUtils printInfo:INFO withString:@"Proceeding to next test"];
     NEXT([self beginWithContext:self.context]);
 }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -215,7 +215,9 @@
         if (__self.currentOutputId == previousOutputId && (__self.simulatorState >= AppLaunched && __self.simulatorState != Completed)) {
             NSString *testClass = (__self.currentClassName ?: __self.previousClassName);
             NSString *testName = (__self.currentTestName ?: __self.previousTestName);
+            BOOL testStartedTruely = [self didTestsStart];
             if (testClass == nil && testName == nil && (__self.simulatorState < TestsStarted)) {
+                testStartedTruely = false;
                 [BPUtils printInfo:ERROR withString:@"It appears that tests have not yet started. The test app has frozen prior to the first test."];
             } else {
                 [BPUtils printInfo:TIMEOUT withString:@" %10.6fs waiting for output from %@/%@",
@@ -223,7 +225,7 @@
                 [[BPStats sharedStats] endTimer:[NSString stringWithFormat:TEST_CASE_FORMAT, [BPStats sharedStats].attemptNumber, testClass, testName]];
             }
             // Set exit status before stopping the tests because stopping the tests will set the SimulatorState to Completed
-            __self.exitStatus = [self didTestsStart] ? BPExitStatusTestTimeout : BPExitStatusAppCrashed;
+            __self.exitStatus = testStartedTruely ? BPExitStatusTestTimeout : BPExitStatusSimulatorCrashed;
             [__self stopTestsWithErrorMessage:@"Timed out waiting for the test to produce output. Test was aboorted."
                                   forTestName:testName
                                       inClass:testClass];

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -215,9 +215,9 @@
         if (__self.currentOutputId == previousOutputId && (__self.simulatorState >= AppLaunched && __self.simulatorState != Completed)) {
             NSString *testClass = (__self.currentClassName ?: __self.previousClassName);
             NSString *testName = (__self.currentTestName ?: __self.previousTestName);
-            BOOL testStartedTruely = [self didTestsStart];
+            BOOL testsReallyStarted = [self didTestsStart];
             if (testClass == nil && testName == nil && (__self.simulatorState < TestsStarted)) {
-                testStartedTruely = false;
+                testsReallyStarted = false;
                 [BPUtils printInfo:ERROR withString:@"It appears that tests have not yet started. The test app has frozen prior to the first test."];
             } else {
                 [BPUtils printInfo:TIMEOUT withString:@" %10.6fs waiting for output from %@/%@",
@@ -225,7 +225,7 @@
                 [[BPStats sharedStats] endTimer:[NSString stringWithFormat:TEST_CASE_FORMAT, [BPStats sharedStats].attemptNumber, testClass, testName]];
             }
             // Set exit status before stopping the tests because stopping the tests will set the SimulatorState to Completed
-            __self.exitStatus = testStartedTruely ? BPExitStatusTestTimeout : BPExitStatusSimulatorCrashed;
+            __self.exitStatus = testsReallyStarted ? BPExitStatusTestTimeout : BPExitStatusSimulatorCrashed;
             [__self stopTestsWithErrorMessage:@"Timed out waiting for the test to produce output. Test was aboorted."
                                   forTestName:testName
                                       inClass:testClass];

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ A full list supported options are listed here.
 |        num-sims        |           -n           | Number of simulators to run in parallel. (bluepill only)                           |     N    | 4                |
 |      plain-output      |           -p           | Print results in plain text.                                                       |     N    | true             |
 |      printf-config     |           -P           | Print a configuration file suitable for passing back using the `-c` option.        |     N    | n/a              |
-|      error-retries     |           -R           | Number of times we'll recover from app crashing/hanging and continue running       |     N    | 5                |
-|    failure-tolerance   |           -f           | The number of retries on any failures (app crash/test failure)                     |     N    | 0                |
+|      error-retries     |           -R           | Number of times to recover from simulator/app crashing/hanging and continue running|     N    | 5                |
+|    failure-tolerance   |           -f           | Number of times to retry on test failures                                          |     N    | 0                |
 |    only-retry-failed   |           -F           | When `failure-tolerance` > 0, only retry tests that failed                         |     N    | false            |
 |         runtime        |           -r           | What runtime to use.                                                               |     N    | iOS 10.3        |
 |      stuck-timeout     |           -S           | Timeout in seconds for a test that seems stuck (no output).                        |     N    | 300s             |


### PR DESCRIPTION
With this change, we have 3 majors flow for the rerun logic.

BPExitStatusTestsFailed -> Retry, require failureTolerance > 0
Tooling failure(BPExitStatusSimulatorCreationFailed,BPExitStatusSimulatorCrashed,BPExitStatusInstallAppFailed,BPExitStatusUninstallAppFailed,BPExitStatusLaunchAppFailed) -> recover from scratch, even if failureTolerance=0. 
BPExitStatusTestTimeout/BPExitStatusAppCrashed -> proceed, even if failureTolerance=0

This will fix one issue which is 'if failureTolerance=0 and tooling failure happens(simulator creation failed/crash), then test will stop and return as fail'. With this change, it will try to recover the tooling failure and rerun it. 

