### PR TITLE
Intentionally breaking UI tests to show issue#200

### DIFF
--- a/BPSampleApp/BPSampleAppUITests/BPSampleAppUITests.m
+++ b/BPSampleApp/BPSampleAppUITests/BPSampleAppUITests.m
@@ -23,10 +23,10 @@
     [super tearDown];
 }
 
-- (void)testExample {
+- (void)testExampleToFail {
     [self.app launch];
     [self.app.buttons[@"Tap Me"] tap];
-    XCUIElement *textField = [[self.app.otherElements containingType:XCUIElementTypeButton identifier:@"Tap Me"] childrenMatchingType:XCUIElementTypeTextField].element;
+    XCUIElement *textField = [[self.app.otherElements containingType:XCUIElementTypeButton identifier:@"Tap Me 2"] childrenMatchingType:XCUIElementTypeTextField].element;
     [textField tap];
     [textField typeText:@"keqiu"];
 }


### PR DESCRIPTION
**DON'T MERGE**

To reproduce issue#200:
1. Build BPSampleAPP (and generate .xctestrun file)
 xcodebuild -workspace Bluepill.xcworkspace -scheme BPSampleApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' build-for-testing -derivedDataPath "./XCTest"
2. Run bluepill
bluepill -p -f 1 -d "iPhone 7" -T "40" --xctestrun-path "XCTest/Build/Products/BPSampleApp_iphonesimulator11.0-x86_64.xctestrun"  -o "./output" -j -i BPSampleAppUITests

And then check ./output folder for results
