### PR TITLE
Default runtime only check the major iOS version number

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -70,7 +70,7 @@
     XCTAssert(self.config.simDeviceType != nil);
 
     for (SimRuntime *runtime in [sc supportedRuntimes]) {
-        if ([[runtime name] isEqualToString:self.config.runtime]) {
+        if ([[runtime name] rangeOfString:self.config.runtime].location != NSNotFound) {
             self.config.simRuntime = runtime;
             break;
         }

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -248,7 +248,11 @@
     if (![[self.device stateString] isEqualToString:@"Shutdown"] && !self.config.testing_NoAppWillRun) {
         [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
         NSAssert(self.appPID > 0, @"Failed to find a valid PID");
-        [BPUtils printInfo:ERROR withString:[BPUtils runShell:[NSString stringWithFormat:@"/usr/bin/sample %d", self.appPID]]];
+        NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd_HH-mm-ss"];
+        NSString *sampleLogFile = [NSString stringWithFormat:@"/tmp/sampleLog_%@.txt", [dateFormatter stringFromDate:[NSDate date]]];
+        [BPUtils printInfo:INFO withString:@"saving 'sample' command log to: %@", sampleLogFile];
+        [BPUtils runShell:[NSString stringWithFormat:@"/usr/bin/sample %d -file %@", self.appPID, sampleLogFile]];
         if ((kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGKILL) < 0)) {
             [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d: %s",
                 self.appPID, strerror(errno)];

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -250,7 +250,7 @@
         NSAssert(self.appPID > 0, @"Failed to find a valid PID");
         NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
         [dateFormatter setDateFormat:@"yyyy-MM-dd_HH-mm-ss"];
-        NSString *sampleLogFile = [NSString stringWithFormat:@"/tmp/sampleLog_%@.txt", [dateFormatter stringFromDate:[NSDate date]]];
+        NSString *sampleLogFile = [NSString stringWithFormat:@"%@/sampleLog_PID_%d_%@.txt", self.config.outputDirectory, self.appPID, [dateFormatter stringFromDate:[NSDate date]]];
         [BPUtils printInfo:INFO withString:@"saving 'sample' command log to: %@", sampleLogFile];
         [BPUtils runShell:[NSString stringWithFormat:@"/usr/bin/sample %d -file %@", self.appPID, sampleLogFile]];
         if ((kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGKILL) < 0)) {

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -245,10 +245,10 @@
     if (!self.config.onlyRetryFailed) {
         [self updateExecutedTestCaseList:testName inClass:testClass];
     }
-
     if (![[self.device stateString] isEqualToString:@"Shutdown"] && !self.config.testing_NoAppWillRun) {
         [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
         NSAssert(self.appPID > 0, @"Failed to find a valid PID");
+        [BPUtils printInfo:ERROR withString:[BPUtils runShell:[NSString stringWithFormat:@"/usr/bin/sample %d", self.appPID]]];
         if ((kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGKILL) < 0)) {
             [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d: %s",
                 self.appPID, strerror(errno)];

--- a/Source/Shared/BPConstants.h
+++ b/Source/Shared/BPConstants.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define BP_DEFAULT_RUNTIME "iOS 11.0"
+#define BP_DEFAULT_RUNTIME "iOS 11"
 #define BP_DEFAULT_DEVICE_TYPE "iPhone 7"
 #define BP_DEFAULT_XCODE_VERSION "Xcode 9"
 #define BP_TM_PROTOCOL_VERSION 17


### PR DESCRIPTION
Xcode9 beta2 only support iOS11.1 run time, while Xcode 9 only support iOS11.0 runtime.