### PR TITLE
Fix a bug where we were loading frameworks from the build directory

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -24,6 +24,10 @@
 #import <objc/runtime.h>
 
 #define NEXT(x)     { [Bluepill setDiagnosticFunction:#x from:__FUNCTION__ line:__LINE__]; CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopCommonModes, ^{ (x); }); }
+#define NEXT_AFTER(delay, x) { \
+    [Bluepill setDiagnosticFunction: #x from:__FUNCTION__ line:__LINE__]; \
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((delay) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ (x); }); \
+}
 
 static int volatile interrupted = 0;
 
@@ -482,7 +486,7 @@ void onInterrupt(int ignore) {
         return;
     }
 
-    NEXT([self checkProcessWithContext:context]);
+    NEXT_AFTER(1, [self checkProcessWithContext:context]);
 }
 
 - (BOOL)isProcessRunningWithContext:(BPExecutionContext *)context {

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -473,7 +473,7 @@ void onInterrupt(int ignore) {
     // If it's not running and we passed the above checks (e.g., the tests are not yet completed)
     // then it must mean the app has crashed.
     // However, we have a short-circuit for tests because those may not actually run any app
-    if (!isRunning && context.pid > 0 && ![context.runner isApplicationStarted] && !self.config.testing_NoAppWillRun) {
+    if (!isRunning && context.pid > 0 && [context.runner isApplicationLaunched] && !self.config.testing_NoAppWillRun) {
         // The tests ended before they even got started or the process is gone for some other reason
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
         [BPUtils printInfo:ERROR withString:@"Application crashed before tests started!"];

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Connections/BPTestBundleConnection.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Connections/BPTestBundleConnection.m
@@ -191,7 +191,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
 - (id)_XCT_testBundleReadyWithProtocolVersion:(NSNumber *)protocolVersion minimumVersion:(NSNumber *)minimumVersion {
     self.connected = YES;
-    [BPUtils printInfo:INFO withString:@"Test bundle is connected.protocolVersion= %d, minimumVersion = %d", protocolVersion, minimumVersion];
+    [BPUtils printInfo:INFO withString:@"Test bundle is connected.protocolVersion= %@, minimumVersion = %@", protocolVersion, minimumVersion];
     return nil;
 }
 

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Connections/BPTestDaemonConnection.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Connections/BPTestDaemonConnection.m
@@ -272,7 +272,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
 // This will add more logs when unimplemented method from XCTestManager_IDEInterface protocol is called
 - (id)handleUnimplementedXCTRequest:(SEL)aSelector {
-    [BPUtils printInfo:DEBUGINFO withString:@"TMD: unimplemented: %@", aSelector];
+    [BPUtils printInfo:DEBUGINFO withString:@"TMD: unimplemented: %s", sel_getName(aSelector)];
     NSAssert(nil, [self unknownMessageForSelector:_cmd]);
     return nil;
 }

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, BPExitStatus) {
 @protocol BPExitStatusProtocol <NSObject>
 
 - (BOOL)isExecutionComplete;
-- (BOOL)isApplicationStarted;
+- (BOOL)isApplicationLaunched;
 - (BOOL)didTestsStart;
 
 - (BPExitStatus)exitStatus;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSInteger, BPExitStatus) {
     BPExitStatusSimulatorReuseFailed = 11,
 };
 
-@protocol BPExitStatusProtocl <NSObject>
+@protocol BPExitStatusProtocol <NSObject>
 
 - (BOOL)isExecutionComplete;
 - (BOOL)isApplicationStarted;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPTreeParser.m
@@ -110,8 +110,8 @@ static const NSString * const kPassed = @"passed";
             [self.log writeLine:@"%@", self.line];
             [self parseLine:self.line];
             if (numLines++ > maxLines) {
-                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%d, %d}, %d, %@",
-                 range.length, range.location, [chunk length], str];
+                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%lu, %lu}, %lu, %@",
+                 (unsigned long)range.length, (unsigned long)range.location, (unsigned long)[chunk length], str];
                 [BPUtils printInfo:ERROR withString:@"Data: %@", chunk];
                 // Fail hard.
                 exit(1);
@@ -237,11 +237,11 @@ static const NSString * const kPassed = @"passed";
                     self.current = node.parent;
                 } else {
                     [BPUtils printInfo:ERROR withString:
-                     [NSString stringWithFormat:@"ERROR: WHERE ARE WE??? We're closing a node for a test suite that hasn't been started [Expected: %@, Current: %@]. Ended: %@\nProblem line: %@",
+                     @"ERROR: WHERE ARE WE??? We're closing a node for a test suite that hasn't been started [Expected: %@, Current: %@]. Ended: %@\nProblem line: %@",
                       testSuiteName,
                       node.testSuiteName,
                       node.ended ? @"YES" : @"NO",
-                      line]];
+                      line];
                 }
                 self.current.endTime = date;
                 self.current.ended = YES;
@@ -298,8 +298,8 @@ static const NSString * const kPassed = @"passed";
                 testCaseLogEntry.errorMessage = errorMessage;
             } else {
                 [BPUtils printInfo:ERROR withString:
-                 [NSString stringWithFormat:@"HOW DID WE GET AN ERROR THAT WASN'T PARSED? We received an error in a test case that wasn't started or did not parse properly.\nProblem line: %@",
-                  line]];
+                 @"HOW DID WE GET AN ERROR THAT WASN'T PARSED? We received an error in a test case that wasn't started or did not parse properly.\nProblem line: %@",
+                  line];
             }
             // Do not set currentTest to nil so that we pick up any stack trace at the end of the log
         }
@@ -441,8 +441,8 @@ static const NSString * const kPassed = @"passed";
                 }
             } else {
                 [BPUtils printInfo:ERROR withString:
-                 [NSString stringWithFormat:@"HOW ON EARTH DID THIS HAPPEN? The test case passed but we failed to handle it properly\nProblem line: %@",
-                  line]];
+                 @"HOW ON EARTH DID THIS HAPPEN? The test case passed but we failed to handle it properly\nProblem line: %@",
+                  line];
             }
             self.currentTest = nil;
         }

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.h
@@ -51,5 +51,5 @@
 - (BOOL)isFinished;
 - (BOOL)needsRetry;
 - (BPExitStatus)exitStatus;
-- (BOOL)isApplicationStarted;
+- (BOOL)isApplicationLaunched;
 @end

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -406,7 +406,7 @@
 }
 
 - (BOOL)isApplicationLaunched {
-    return !self.appProcessFinished && [self.monitor isApplicationLaunched];
+    return [self.monitor isApplicationLaunched];
 }
 
 - (BOOL)didTestStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -405,8 +405,8 @@
     return [self checkFinished];
 }
 
-- (BOOL)isApplicationStarted {
-    return self.appProcessFinished || [self.monitor isApplicationStarted];
+- (BOOL)isApplicationLaunched {
+    return !self.appProcessFinished || [self.monitor isApplicationLaunched];
 }
 
 - (BOOL)didTestStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -44,12 +44,12 @@
     NSError *error;
     SimServiceContext *sc = [SimServiceContext sharedServiceContextForDeveloperDir:self.config.xcodePath error:&error];
     if (!sc) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimServiceContext failed: %@", [error localizedDescription]]];
+        [BPUtils printInfo:ERROR withString:@"SimServiceContext failed: %@", [error localizedDescription]];
         return;
     }
     SimDeviceSet *deviceSet = [sc defaultDeviceSetWithError:&error];
     if (!deviceSet) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimDeviceSet failed: %@", [error localizedDescription]]];
+        [BPUtils printInfo:ERROR withString:@"SimDeviceSet failed: %@", [error localizedDescription]];
         return;
     }
 
@@ -83,20 +83,20 @@
 - (BOOL)useSimulatorWithDeviceUDID:(NSUUID *)deviceUDID {
     self.device = [self findDeviceWithConfig:self.config andDeviceID:deviceUDID];
     if (!self.device) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimDevice not found: %@", [deviceUDID UUIDString]]];
+        [BPUtils printInfo:ERROR withString:@"SimDevice not found: %@", [deviceUDID UUIDString]];
         return NO;
     }
 
     if (![self.device.stateString isEqualToString:@"Booted"]) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimDevice exists, but not booted: %@", [deviceUDID UUIDString]]];
+        [BPUtils printInfo:ERROR withString:@"SimDevice exists, but not booted: %@", [deviceUDID UUIDString]];
         return NO;
     }
 
     if (!self.config.headlessMode) {
         self.app = [self findSimGUIApp];
         if (!self.app) {
-            [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimDevice running, but no running Simulator App in non-headless mode: %@",
-                                                 [deviceUDID UUIDString]]];
+            [BPUtils printInfo:ERROR withString:@"SimDevice running, but no running Simulator App in non-headless mode: %@",
+                                                 [deviceUDID UUIDString]];
             return NO;
         }
     }
@@ -136,7 +136,7 @@
         [BPUtils printInfo:ERROR withString:@"Simulator %@ failed to boot. State: %@", self.device.UDID.UUIDString, self.device.stateString];
         return [NSError errorWithDomain:@"Simulator failed to boot" code:-1 userInfo:nil];
     }
-    [BPUtils printInfo:INFO withString:@"Simulator %@ achieved the BOOTED state", self.device.UDID.UUIDString, self.device.stateString];
+    [BPUtils printInfo:INFO withString:@"Simulator %@ achieved the BOOTED state %@", self.device.UDID.UUIDString, self.device.stateString];
     return nil;
 }
 
@@ -144,12 +144,12 @@
     NSError *error;
     SimServiceContext *sc = [SimServiceContext sharedServiceContextForDeveloperDir:config.xcodePath error:&error];
     if (!sc) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimServiceContext failed: %@", [error localizedDescription]]];
+        [BPUtils printInfo:ERROR withString:@"SimServiceContext failed: %@", [error localizedDescription]];
         return nil;
     }
     SimDeviceSet *deviceSet = [sc defaultDeviceSetWithError:&error];
     if (!deviceSet) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimDeviceSet failed: %@", [error localizedDescription]]];
+        [BPUtils printInfo:ERROR withString:@"SimDeviceSet failed: %@", [error localizedDescription]];
         return nil;
     }
 
@@ -176,7 +176,7 @@
         NSError *error;
         BOOL uploadResult = [self.device addVideo:videoUrl error:&error];
         if (!uploadResult) {
-            [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to upload video at path: %@, error message: %@", urlString, [error description]]];
+            [BPUtils printInfo:ERROR withString:@"Failed to upload video at path: %@, error message: %@", urlString, [error description]];
         }
     }
 }
@@ -187,7 +187,7 @@
         NSError *error;
         BOOL uploadResult = [self.device addPhoto:photoUrl error:&error];
         if (!uploadResult) {
-            [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to upload photo at path: %@, error message: %@", urlString, [error description]]];
+            [BPUtils printInfo:ERROR withString:@"Failed to upload photo at path: %@, error message: %@", urlString, [error description]];
         }
     }
 }

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -406,7 +406,7 @@
 }
 
 - (BOOL)isApplicationLaunched {
-    return !self.appProcessFinished || [self.monitor isApplicationLaunched];
+    return !self.appProcessFinished && [self.monitor isApplicationLaunched];
 }
 
 - (BOOL)didTestStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -63,8 +63,10 @@
                                             config:(BPConfiguration *)config {
     NSString *hostAppExecPath = [SimulatorHelper executablePathforPath:config.appBundlePath];
     NSString *testSimulatorFrameworkPath = [[hostAppExecPath stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
-    NSString *dyldLibraryPath = [NSString stringWithFormat:@"%@:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", testSimulatorFrameworkPath, config.xcodePath];
+    NSString *dyldLibraryPath = [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath];
     NSMutableDictionary<NSString *, NSString *> *environment = [@{
+//                                                                  @"DYLD_PRINT_ENV": @YES,
+//                                                                  @"DYLD_PRINT_LIBRARIES": @YES,
                                                                   @"DYLD_FALLBACK_FRAMEWORK_PATH" : [NSString stringWithFormat:@"%@/Library/Frameworks:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath, config.xcodePath],
                                                                   @"DYLD_FRAMEWORK_PATH" : dyldLibraryPath,
                                                                   @"DYLD_INSERT_LIBRARIES" : [NSString stringWithFormat:@"%@/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Developer/usr/lib/libXCTTargetBootstrapInject.dylib", config.xcodePath],

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, SimulatorState) {
 @class SimDevice;
 @class BPConfiguration;
 
-@interface SimulatorMonitor : NSObject<BPExecutionPhaseProtocol, BPExitStatusProtocl>
+@interface SimulatorMonitor : NSObject<BPExecutionPhaseProtocol, BPExitStatusProtocol>
 
 @property (nonatomic, strong) SimDevice *device;
 @property (nonatomic, strong) NSString *hostBundleId;

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -267,8 +267,8 @@
     return (self.simulatorState == Completed);
 }
 
-- (BOOL)isApplicationStarted {
-    return (self.simulatorState != Idle);
+- (BOOL)isApplicationLaunched {
+    return (self.simulatorState == AppLaunched);
 }
 
 - (BOOL)didTestsStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -268,7 +268,7 @@
 }
 
 - (BOOL)isApplicationLaunched {
-    return (self.simulatorState > Idle);
+    return (self.simulatorState > Idle && self.simulatorState < Completed);
 }
 
 - (BOOL)didTestsStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -268,7 +268,7 @@
 }
 
 - (BOOL)isApplicationLaunched {
-    return (self.simulatorState == AppLaunched);
+    return (self.simulatorState > Idle);
 }
 
 - (BOOL)didTestsStart {

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorScreenshotService.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorScreenshotService.m
@@ -134,7 +134,7 @@
                                             error:&error];
 
     if (!service) {
-        [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"Failed to create SimDeviceFramebufferService for device:%@, error:%@", _device.UDID.UUIDString, [error localizedDescription]]];
+        [BPUtils printInfo:ERROR withString:@"Failed to create SimDeviceFramebufferService for device:%@, error:%@", _device.UDID.UUIDString, [error localizedDescription]];
     }
     return service;
 }

--- a/Bluepill-cli/Bluepill-cli/main.m
+++ b/Bluepill-cli/Bluepill-cli/main.m
@@ -108,7 +108,7 @@ int main(int argc, char * argv[]) {
             [[BPStats sharedStats] exitWithWriter:statsWriter exitCode:exitCode andCreateFullReport:YES];
         }
 
-        [BPUtils printInfo:INFO withString:@"BP exiting %d", exitCode];
+        [BPUtils printInfo:INFO withString:@"BP exiting %ld", (long)exitCode];
         return exitCode;
     }
 }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -180,11 +180,11 @@ maxprocs(void)
     }
     if (bundles.count < numSims) {
         [BPUtils printInfo:WARNING
-                withString:[NSString stringWithFormat:@"Lowering number of simulators from %lu to %lu because there aren't enough tests.",
-                            numSims, bundles.count]];
+                withString:@"Lowering number of simulators from %lu to %lu because there aren't enough tests.",
+                            numSims, bundles.count];
     }
-    [BPUtils printInfo:INFO withString:[NSString stringWithFormat:@"Running with %lu simulator%s.",
-                                        (unsigned long)numSims, (numSims > 1) ? "s" : ""]];
+    [BPUtils printInfo:INFO withString:@"Running with %lu simulator%s.",
+     (unsigned long)numSims, (numSims > 1) ? "s" : ""];
     NSArray *copyBundles = [NSMutableArray arrayWithArray:bundles];
     for (int i = 1; i < [self.config.repeatTestsCount integerValue]; i++) {
         [bundles addObjectsFromArray:copyBundles];
@@ -215,7 +215,7 @@ maxprocs(void)
                 exit(0);
             }
             if (interrupted != old_interrupted) {
-                [BPUtils printInfo:WARNING withString:[NSString stringWithFormat:@"Received interrupt (Ctrl-C) %d times, waiting for child processes to finish.", interrupted]];
+                [BPUtils printInfo:WARNING withString:@"Received interrupt (Ctrl-C) %d times, waiting for child processes to finish.", interrupted];
                 old_interrupted = interrupted;
             }
             [self interrupt];
@@ -273,7 +273,7 @@ maxprocs(void)
             }
             [BPUtils printInfo:INFO withString:@"%lu Simulator%s still running. [%@]",
              launchedTasks, launchedTasks == 1 ? "" : "s", listString];
-            [BPUtils printInfo:INFO withString:[NSString stringWithFormat:@"Using %d of %d processes.", numprocs(), maxProcs]];
+            [BPUtils printInfo:INFO withString:@"Using %d of %d processes.", numprocs(), maxProcs];
 
         }
         seconds += 1;
@@ -323,7 +323,7 @@ maxprocs(void)
     NSError *error;
     NSString *idStr = [NSString stringWithContentsOfFile:tempFilePath encoding:NSUTF8StringEncoding error:&error];
     if (!idStr) {
-        [BPUtils printInfo:ERROR withString:@"ERROR: Failed to read the device ID file %@ with error:", tempFilePath, [error localizedDescription]];
+        [BPUtils printInfo:ERROR withString:@"ERROR: Failed to read the device ID file %@ with error: %@", tempFilePath, [error localizedDescription]];
     }
     return idStr;
 }

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -63,7 +63,7 @@
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
-    XCTAssert(rc == 0);
+    XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
     XCTAssert([runner.nsTaskList count] == 0);
 }
 

--- a/Source/Shared/BPUtils.h
+++ b/Source/Shared/BPUtils.h
@@ -74,7 +74,7 @@ typedef NS_ENUM(int, BPKind) {
  @param kind one of the levels in BPKind
  @param fmt a format string (a la printf), followed by the var args.
  */
-+ (void)printInfo:(BPKind)kind withString:(NSString *)fmt, ...;
++ (void)printInfo:(BPKind)kind withString:(NSString *)fmt, ... NS_FORMAT_FUNCTION(2,3);
 
 /*!
  @discussion get an NSError *

--- a/Source/Shared/BPXCTestFile.m
+++ b/Source/Shared/BPXCTestFile.m
@@ -166,8 +166,10 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
     if (commandLineArguments) {
         xcTestFile.commandLineArguments = [[NSArray alloc] initWithArray:commandLineArguments];
     }
-    NSDictionary<NSString *, NSString *> *environment = [dict objectForKey:@"EnvironmentVariables"];
+    NSMutableDictionary<NSString *, NSString *> *environment = [dict objectForKey:@"EnvironmentVariables"];
     if (environment) {
+        [environment removeObjectForKey:@"DYLD_FRAMEWORK_PATH"];
+        [environment removeObjectForKey:@"DYLD_LIBRARY_PATH"];
         xcTestFile.environmentVariables = [[NSDictionary alloc] initWithDictionary:environment];
     }
     NSArray<NSString *> *skipTestIdentifiers = [dict objectForKey:@"SkipTestIdentifiers"];


### PR DESCRIPTION
This is a fun one... xcodebuild build-for-testing adds the derivedData directory  to the DYLD_FRAMEWORK_PATH and DYLD_LIBRARY_PATH environment  variables so that if a framework is built but not added to the app bundle, the app will still load in the simulator. Obviously, once the app is installed in an actual device it won't load.

This commit clears up those variables so that the only frameworks available to the app are the ones bundled with it. It also fixes the logic for detecting a crashed application which was wrong (if the app crashed early enough, like when loading dynamic libraries).

Also clean up all the info message format strings by adding the proper compiler directives.