### PR TITLE
README: Fix script path on how to build Bluepill from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you're using [Fastlane](https://github.com/fastlane/fastlane) to run your tes
 
 - How to get Bluepill binary from source?
 
-  Run `./bluepill.sh build` to test and build Bluepill. The binary will be output in the ./build folder.
+  Run `./scripts/bluepill.sh build` to test and build Bluepill. The binary will be output in the ./build folder.
 
 - How to test my changes to Bluepill?
 


### PR DESCRIPTION
Hey,

as I tried building Bluepill from source I noticed that the path mentioned in the README file isn't valid (anymore). As `bluepill.sh` is located in the `scripts` folder, but needs to be run from the root-directory the path should include the folder name (as it does already for the test changes against bluepill part). 