### PR TITLE
Fix #125 invalid character (backspace) in output

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPReporters.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPReporters.m
@@ -151,6 +151,8 @@ void Output(NSMutableString *appendTo, NSString *fmt, ...);
     [string replaceOccurrencesOfString:@"'"  withString:@"&#x27;" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@">"  withString:@"&gt;"   options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"<"  withString:@"&lt;"   options:NSLiteralSearch range:NSMakeRange(0, [string length])];
+    // Replace UTF-8 Backspace
+    [string replaceOccurrencesOfString:@"\x08" withString:@"&#x8;" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
 
     return [NSString stringWithString:string];
 }


### PR DESCRIPTION
If you clear text in a UITest by pressing backspace, Xcode logs output into console with the UTF-8 character \x08.

 This results into the following error message when parsing JUnit output:

```
org.dom4j.DocumentException: Error on line 496 of document  : An invalid XML character (Unicode: 0x8) was found in the element content of the document. Nested exception: An invalid XML character (Unicode: 0x8) was found in the element content of the document.
```

To fix this, I’ve replaced the character with the HTML Entity counterpart:

```
t =    10.54s Type &#x27;&#x8;&#x8;&#x8;&#x8;&#x8;&#x8;&#x27; into &quot;TestTextField&quot; TextField
```

This fixes #125.

As I didn’t write any production Objective-C code yet as I started with Swift only please let me know if there’s anything I can improve or needs to be changed.

I couldn’t find any specific unit test for this method to adjust. If there is any I would try to make it test my change. Otherwise I could also provide an XML file with one test case where this specific problem occurs.