### PR TITLE
Simplify SimulatorMonitor and fix races

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -52,7 +52,6 @@
     self.config.junitOutput = NO;
     self.config.testRunnerAppPath = nil;
     self.config.testing_CrashAppOnLaunch = NO;
-    self.config.testing_NoAppWillRun = YES;
     NSString *path = @"testScheme.xcscheme";
     self.config.schemePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:path];
     [BPUtils quietMode:[BPUtils isBuildScript]];
@@ -89,24 +88,18 @@
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testing_CrashAppOnLaunch = YES;
-    self.config.testing_NoAppWillRun = NO;
     self.config.stuckTimeout = @3;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
-    XCTAssert(exitCode == BPExitStatusSimulatorCrashed, @"Expected: %ld Got: %ld", (long)BPExitStatusAppCrashed, (long)exitCode);
-
-    self.config.testing_NoAppWillRun = YES;
+    XCTAssert(exitCode == BPExitStatusAppCrashed, @"Expected: %ld Got: %ld", (long)BPExitStatusAppCrashed, (long)exitCode);
 }
 
 - (void)testAppThatHangsOnLaunch {
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testing_HangAppOnLaunch = YES;
-    self.config.testing_NoAppWillRun = NO;
     self.config.stuckTimeout = @3;
     BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusSimulatorCrashed);
-
-    self.config.testing_NoAppWillRun = YES;
 }
 
 - (void)testRecoverSimulatorOnCrash {
@@ -117,14 +110,11 @@
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testing_HangAppOnLaunch = YES;
-    self.config.testing_NoAppWillRun = NO;
     self.config.stuckTimeout = @3;
     self.config.failureTolerance = @0;
     self.config.errorRetriesCount = @1;
     BPExitStatus exitCode = [[[Bluepill alloc] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusSimulatorCrashed, @"Expected: %ld Got: %ld", (long)BPExitStatusSimulatorCrashed, (long)exitCode);
-
-    self.config.testing_NoAppWillRun = YES;
 
     NSString *simulator1Path = [outputDir stringByAppendingPathComponent:@"1-simulator.log"];
     NSString *simulator2Path = [outputDir stringByAppendingPathComponent:@"2-simulator.log"];

--- a/Bluepill-cli/BPInstanceTests/Resource Files/hanging_tests.xml
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/hanging_tests.xml
@@ -4,8 +4,9 @@
         <testsuite tests="1" failures="1" errors="0" name="BPSampleAppHangingTests">
             <testcase classname="BPSampleAppHangingTests" name="testAppHanging">
                 <failure type="Failure" message="Timed out waiting for the test to produce output. Test was aborted.">
-Unknown File:0
                 </failure>
+                <system-out>
+                </system-out>
             </testcase>
         </testsuite>
     </testsuite>

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -490,7 +490,7 @@ void onInterrupt(int ignore) {
     if (!isRunning && context.pid > 0 && [context.runner isApplicationLaunched] && !self.config.testing_NoAppWillRun) {
         // The tests ended before they even got started or the process is gone for some other reason
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
-        [BPUtils printInfo:ERROR withString:@"Application crashed before tests started!"];
+        [BPUtils printInfo:ERROR withString:@"Application crashed!"];
         [[BPStats sharedStats] addApplicationCrash];
         [self deleteSimulatorWithContext:context andStatus:BPExitStatusAppCrashed];
         return;

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -314,7 +314,7 @@
     [self.device launchApplicationAsyncWithID:hostBundleId options:options completionHandler:^(NSError *error, pid_t pid) {
         // Save the process ID to the monitor
         blockSelf.monitor.appPID = pid;
-        blockSelf.monitor.appState = AppRunning;
+        blockSelf.monitor.appState = Running;
 
         [blockSelf.stdOutHandle writeData:[@"DEBUG_FLAG_TOBEREMOVED.\n" dataUsingEncoding:NSUTF8StringEncoding]];
 
@@ -327,7 +327,7 @@
                 dispatch_source_cancel(source);
             });
             dispatch_source_set_cancel_handler(source, ^{
-                blockSelf.monitor.appState = AppFinished;
+                blockSelf.monitor.appState = Completed;
                 // Post a APPCLOSED signal to the fifo
                 [blockSelf.stdOutHandle writeData:[@"\nBP_APP_PROC_ENDED\n" dataUsingEncoding:NSUTF8StringEncoding]];
             });

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -25,7 +25,6 @@
 @property (nonatomic, strong) NSRunningApplication *app;
 @property (nonatomic, strong) NSFileHandle *stdOutHandle;
 @property (nonatomic, assign) BOOL needsRetry;
-@property (nonatomic, assign) BOOL appProcessFinished;
 
 @end
 
@@ -315,7 +314,7 @@
     [self.device launchApplicationAsyncWithID:hostBundleId options:options completionHandler:^(NSError *error, pid_t pid) {
         // Save the process ID to the monitor
         blockSelf.monitor.appPID = pid;
-        blockSelf.monitor.simulatorState = AppLaunched;
+        blockSelf.monitor.appState = AppRunning;
 
         [blockSelf.stdOutHandle writeData:[@"DEBUG_FLAG_TOBEREMOVED.\n" dataUsingEncoding:NSUTF8StringEncoding]];
 
@@ -328,8 +327,8 @@
                 dispatch_source_cancel(source);
             });
             dispatch_source_set_cancel_handler(source, ^{
+                blockSelf.monitor.appState = AppFinished;
                 // Post a APPCLOSED signal to the fifo
-                blockSelf.appProcessFinished = YES;
                 [blockSelf.stdOutHandle writeData:[@"\nBP_APP_PROC_ENDED\n" dataUsingEncoding:NSUTF8StringEncoding]];
             });
             dispatch_resume(source);

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
@@ -12,12 +12,22 @@
 #import "BPExitStatus.h"
 #import "SimulatorScreenshotService.h"
 
-typedef NS_ENUM(NSInteger, SimulatorState) {
-    Idle,
-    AppLaunched,
-    Running,
-    TestsStarted,
-    Completed
+typedef NS_ENUM(NSInteger, TestsState) {
+    TestsIdle,
+    TestsRunning,
+    TestsCompleted
+};
+
+typedef NS_ENUM(NSInteger, AppState) {
+    AppIdle,
+    AppRunning,
+    AppFinished
+};
+
+typedef NS_ENUM(NSInteger, ParserState) {
+    ParserIdle,
+    ParserRunning,
+    ParserFinished
 };
 
 @class SimDevice;
@@ -27,7 +37,9 @@ typedef NS_ENUM(NSInteger, SimulatorState) {
 
 @property (nonatomic, strong) SimDevice *device;
 @property (nonatomic, strong) NSString *hostBundleId;
-@property (nonatomic, assign) SimulatorState simulatorState;
+@property (nonatomic, assign) AppState appState;
+@property (nonatomic, assign) ParserState parserState;
+@property (nonatomic, assign) TestsState testsState;
 @property (nonatomic, strong) SimulatorScreenshotService *screenshotService;
 @property (nonatomic) pid_t appPID;
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.h
@@ -12,22 +12,10 @@
 #import "BPExitStatus.h"
 #import "SimulatorScreenshotService.h"
 
-typedef NS_ENUM(NSInteger, TestsState) {
-    TestsIdle,
-    TestsRunning,
-    TestsCompleted
-};
-
-typedef NS_ENUM(NSInteger, AppState) {
-    AppIdle,
-    AppRunning,
-    AppFinished
-};
-
-typedef NS_ENUM(NSInteger, ParserState) {
-    ParserIdle,
-    ParserRunning,
-    ParserFinished
+typedef NS_ENUM(NSInteger, State) {
+    Idle,
+    Running,
+    Completed
 };
 
 @class SimDevice;
@@ -37,9 +25,9 @@ typedef NS_ENUM(NSInteger, ParserState) {
 
 @property (nonatomic, strong) SimDevice *device;
 @property (nonatomic, strong) NSString *hostBundleId;
-@property (nonatomic, assign) AppState appState;
-@property (nonatomic, assign) ParserState parserState;
-@property (nonatomic, assign) TestsState testsState;
+@property (nonatomic, assign) State appState;
+@property (nonatomic, assign) State parserState;
+@property (nonatomic, assign) State testsState;
 @property (nonatomic, strong) SimulatorScreenshotService *screenshotService;
 @property (nonatomic) pid_t appPID;
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -41,7 +41,9 @@
         self.config = config;
         self.maxTimeWithNoOutput = [config.stuckTimeout integerValue];
         self.maxTestExecutionTime = [config.testCaseTimeout integerValue];
-        self.simulatorState = Idle;
+        self.appState = AppIdle;
+        self.parserState = ParserIdle;
+        self.testsState = TestsIdle;
         self.exitStatus = 0;
     }
     return self;
@@ -52,7 +54,7 @@
 }
 
 - (void)onAllTestsBegan {
-    self.simulatorState = Running;
+    self.testsState = TestsRunning;
     // Don't overwrite the original start time on secondary attempts
     if ([BPStats sharedStats].cleanRun) {
         [BPStats sharedStats].cleanRun = NO;
@@ -62,7 +64,7 @@
 }
 
 - (void)onAllTestsEnded {
-    self.simulatorState = Completed;
+    self.testsState = TestsCompleted;
 
     if (self.failureCount) {
         self.exitStatus = BPExitStatusTestsFailed;
@@ -77,14 +79,14 @@
     [[BPStats sharedStats] startTimer:[NSString stringWithFormat:TEST_CASE_FORMAT, [BPStats sharedStats].attemptNumber, testClass, testName]];
     self.lastTestCaseStartDate = [NSDate date];
 
-    self.simulatorState = TestsStarted;
+    self.testsState = TestsRunning;
 
     self.currentTestName = testName;
     self.currentClassName = testClass;
 
     __weak typeof(self) __self = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.maxTestExecutionTime * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if ([__self.currentTestName isEqualToString:testName] && [__self.currentClassName isEqualToString:testClass] && __self.simulatorState == TestsStarted) {
+        if ([__self.currentTestName isEqualToString:testName] && [__self.currentClassName isEqualToString:testClass] && __self.testsState == TestsRunning) {
             [BPUtils printInfo:TIMEOUT withString:@"%10.6fs %@/%@", __self.maxTestExecutionTime, testClass, testName];
             [__self stopTestsWithErrorMessage:@"Test took too long to execute and was aborted." forTestName:testName inClass:testClass];
             __self.exitStatus = BPExitStatusTestTimeout;
@@ -189,8 +191,9 @@
 - (void)onOutputReceived:(NSString *)output {
     NSDate *currentTime = [NSDate date];
 
-    if (self.simulatorState == Idle) {
-        self.simulatorState = AppLaunched;
+    assert(self.parserState != ParserFinished);
+    if (self.parserState == ParserIdle) {
+        self.parserState = ParserRunning;
     }
 
     self.currentOutputId++; // Increment the Output ID for this instance since we've moved on to the next bit of output
@@ -199,22 +202,30 @@
     __weak typeof(self) __self = self;
 
     // App crashed
-    if ([output isEqualToString:@"BP_APP_PROC_ENDED"] && __self.simulatorState == TestsStarted) {
-        [BPUtils printInfo:CRASH withString:@"%@/%@ crashed app.",
-                                             (self.currentClassName ?: self.previousClassName),
-                                             (self.currentTestName ?: self.previousTestName)];
-        [self stopTestsWithErrorMessage:@"App Crashed"
-                              forTestName:(self.currentTestName ?: self.previousTestName)
-                                  inClass:(self.currentClassName ?: self.previousClassName)];
-        self.exitStatus = BPExitStatusAppCrashed;
-        [[BPStats sharedStats] addApplicationCrash];
+    if ([output isEqualToString:@"BP_APP_PROC_ENDED"]) {
+        __self.parserState = ParserFinished;
+        if (__self.testsState == TestsRunning || __self.testsState == TestsIdle) {
+            if (__self.testsState == TestsRunning) {
+                [BPUtils printInfo:CRASH withString:@"%@/%@ crashed app.",
+                 (self.currentClassName ?: self.previousClassName),
+                 (self.currentTestName ?: self.previousTestName)];
+            } else {
+                assert(__self.testsState == TestsIdle);
+                [BPUtils printInfo:CRASH withString:@"App crashed before tests started."];
+            }
+            [self stopTestsWithErrorMessage:@"App Crashed"
+                                forTestName:(self.currentTestName ?: self.previousTestName)
+                                    inClass:(self.currentClassName ?: self.previousClassName)];
+            self.exitStatus = BPExitStatusAppCrashed;
+            [[BPStats sharedStats] addApplicationCrash];
+        }
     }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(__self.maxTimeWithNoOutput * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (__self.currentOutputId == previousOutputId && (__self.simulatorState >= AppLaunched && __self.simulatorState != Completed)) {
+        if (__self.currentOutputId == previousOutputId && (__self.appState == AppRunning)) {
             NSString *testClass = (__self.currentClassName ?: __self.previousClassName);
             NSString *testName = (__self.currentTestName ?: __self.previousTestName);
             BOOL testsReallyStarted = [self didTestsStart];
-            if (testClass == nil && testName == nil && (__self.simulatorState < TestsStarted)) {
+            if (testClass == nil && testName == nil && (__self.appState == AppRunning)) {
                 testsReallyStarted = false;
                 [BPUtils printInfo:ERROR withString:@"It appears that tests have not yet started. The test app has frozen prior to the first test."];
             } else {
@@ -239,7 +250,7 @@
     if (!self.config.onlyRetryFailed) {
         [self updateExecutedTestCaseList:testName inClass:testClass];
     }
-    if (![[self.device stateString] isEqualToString:@"Shutdown"] && !self.config.testing_NoAppWillRun) {
+    if (self.appState == AppRunning && !self.config.testing_NoAppWillRun) {
         [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
         NSAssert(self.appPID > 0, @"Failed to find a valid PID");
         NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
@@ -253,20 +264,20 @@
         }
     }
 
-    self.simulatorState = Completed;
+    self.testsState = TestsCompleted;
     [self.callback onTestAbortedWithName:testName inClass:testClass errorMessage:message];
 }
 
 - (BOOL)isExecutionComplete {
-    return (self.simulatorState == Completed);
+    return (self.parserState == ParserFinished && self.testsState == TestsCompleted && self.appState == AppFinished);
 }
 
 - (BOOL)isApplicationLaunched {
-    return (self.simulatorState > Idle && self.simulatorState < Completed);
+    return (self.appState == AppRunning);
 }
 
 - (BOOL)didTestsStart {
-    return (self.simulatorState >= Running);
+    return (self.testsState == TestsRunning);
 }
 
 - (void)saveScreenshotForFailedTestWithName:(NSString *)testName inClass:(NSString *)testClass {

--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,5 @@ compile:
 
 test:
   override:
-    - ./scripts/bluepill.sh instance_tests1 
-    - ./scripts/bluepill.sh instance_tests2 
-    - ./scripts/bluepill.sh instance_tests3 
-    - ./scripts/bluepill.sh runner_tests 
+    - ./scripts/bluepill.sh test
 

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -137,6 +137,7 @@ bluepill_integration_tests()
   if ! grep '\*\* TEST SUCCEEDED \*\*' result.txt; then
     echo 'Test failed'
     echo See result.txt for details
+    cat results.txt
     exit 1
   fi
 }


### PR DESCRIPTION
SimulatorMonitor was trying to keep track of multiple things using a
single state variable which caused a bunch of problems. One of them
was a race between when the app finishes (the process exits) and the
output parser has finished parsing. We use a FIFO for grabbing the
output so it's buffered. This means that after the app has finished,
the parser is still parsing for short while (how short depends on how
fast the machine is).