### PR TITLE
Removing trailing parantheses from test names

### DIFF
--- a/BPSampleApp/BPSampleApp.xcodeproj/project.pbxproj
+++ b/BPSampleApp/BPSampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		32FEEBBD2012B93D005916EF /* BPSampleAppSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FEEBBC2012B93D005916EF /* BPSampleAppSwiftTests.swift */; };
 		BA4BCFC91DC47EC800592FA4 /* BPSampleAppHangingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA4BCFC81DC47EC800592FA4 /* BPSampleAppHangingTests.m */; };
 		BA9C2DD51DD7F182007CB967 /* BPSampleAppFatalErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA9C2DD41DD7F182007CB967 /* BPSampleAppFatalErrorTests.m */; };
 		BA9C2DDE1DD7F7D9007CB967 /* BPSampleAppSwiftFatalErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C2DDD1DD7F7D9007CB967 /* BPSampleAppSwiftFatalErrorTests.swift */; };
@@ -68,6 +69,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		32FEEBBB2012B93D005916EF /* BPSampleAppTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BPSampleAppTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		32FEEBBC2012B93D005916EF /* BPSampleAppSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSampleAppSwiftTests.swift; sourceTree = "<group>"; };
 		BA4BCFC61DC47EC700592FA4 /* BPSampleAppHangingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BPSampleAppHangingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA4BCFC81DC47EC800592FA4 /* BPSampleAppHangingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPSampleAppHangingTests.m; sourceTree = "<group>"; };
 		BA4BCFCA1DC47EC800592FA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -239,6 +242,8 @@
 			children = (
 				BAB24F4B1DB5D45E00867756 /* BPSampleAppTests.m */,
 				BAB24F4D1DB5D45E00867756 /* Info.plist */,
+				32FEEBBC2012B93D005916EF /* BPSampleAppSwiftTests.swift */,
+				32FEEBBB2012B93D005916EF /* BPSampleAppTests-Bridging-Header.h */,
 			);
 			path = BPSampleAppTests;
 			sourceTree = "<group>";
@@ -424,6 +429,7 @@
 					BAB24F461DB5D45E00867756 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = 57Y47U492U;
+						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 						TestTargetID = BAB24F2D1DB5D45E00867756;
 					};
@@ -561,6 +567,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BAB24F4C1DB5D45E00867756 /* BPSampleAppTests.m in Sources */,
+				32FEEBBD2012B93D005916EF /* BPSampleAppSwiftTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -855,11 +862,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 57Y47U492U;
 				INFOPLIST_FILE = BPSampleAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = LI.BPSampleAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BPSampleAppTests/BPSampleAppTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BPSampleApp.app/BPSampleApp";
 			};
 			name = Debug;
@@ -868,11 +879,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 57Y47U492U;
 				INFOPLIST_FILE = BPSampleAppTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = LI.BPSampleAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BPSampleAppTests/BPSampleAppTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BPSampleApp.app/BPSampleApp";
 			};
 			name = Release;

--- a/BPSampleApp/BPSampleAppTests/BPSampleAppSwiftTests.swift
+++ b/BPSampleApp/BPSampleAppTests/BPSampleAppSwiftTests.swift
@@ -1,0 +1,18 @@
+//
+//  BPSampleAppSwiftTests.swift
+//  BPSampleAppTests
+//
+//  Created by Prince S. Valluri on 1/19/18.
+//  Copyright © 2018 LinkedIn. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class BPSampleAppSwiftTests: XCTestCase {
+    func testZPass() {
+        XCTAssert(true)
+    }
+    
+}
+

--- a/BPSampleApp/BPSampleAppTests/BPSampleAppTests-Bridging-Header.h
+++ b/BPSampleApp/BPSampleAppTests/BPSampleAppTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPConfigurationTests.m
@@ -57,6 +57,15 @@
     XCTAssert([config.schemePath isEqualToString:@"/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme"]);
     XCTAssertEqual(config.headlessMode, NO);
     XCTAssert([config.outputDirectory isEqualToString:@"/Users/khu/tmp/simulator"]);
+
+    XCTAssert([config.testCasesToRun count] == 3);
+    XCTAssert([config.testCasesToRun containsObject:@"FeedControlMenuActionsShareViaTests/testShareViaOnArticleShareUpdate"]);
+    XCTAssert([config.testCasesToRun containsObject:@"FeedLoadMoreCommentsTrackingTest/testLoadMoreCommentsInFeedDetail"]);
+    XCTAssert([config.testCasesToRun containsObject:@"FeedSponsoredDownVariantTrackingTest/testTapOnCompanyPictureInDetail"]);
+
+    XCTAssert([config.testCasesToSkip count] == 2);
+    XCTAssert([config.testCasesToSkip containsObject:@"FeedShareActorActionTrackingTest/testShareActorDescriptionTrackingInFeedDetail"]);
+    XCTAssert([config.testCasesToSkip containsObject:@"FeedAnnotationActionTrackingTest/testMentionAnnotationTrackingInFeedDetail"]);
 }
 
 - (void)testConfigFileWithRelativePathLoading {

--- a/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
+++ b/Bluepill-cli/BPInstanceTests/BPUtilsTests.m
@@ -100,4 +100,14 @@
     XCTAssertFalse([[NSSet setWithArray:normalizedConfig.testCasesToRun] isEqualToSet:testCasesNotToRun]);
 }
 
+- (void) testTrailingParanthesesInTestNames {
+    NSMutableSet *testCasesWithParantheses = [NSMutableSet new];
+    for (NSString *testCase in self.xcTestFile.allTestCases) {
+        if ([testCase containsString:@"("] || [testCase containsString:@")"]) {
+            [testCasesWithParantheses addObject:testCase];
+        }
+    }
+    XCTAssert([testCasesWithParantheses count] == 0);
+}
+
 @end

--- a/Bluepill-cli/BPInstanceTests/Resource Files/testConfig.json
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/testConfig.json
@@ -2,10 +2,19 @@
     "app": "/Users/khu/Library/Developer/Xcode/DerivedData/voyager-frhgmrtfxqiflycndwcgfpqkbhdy/Build/Products/Debug-iphonesimulator/LinkedIn.app",
     "no-split": [
                  "VoyagerTests"
-                 ],
+    ],
     "error-retries": 0,
     "scheme-path": "/Users/khu/ios/dev/voyager-ios_trunk/Voyager.xcodeproj/xcshareddata/xcschemes/VoyagerScenarioTests4.xcscheme",
     "repeat-count": 1,
     "output-dir": "/Users/khu/tmp/simulator",
-    "headless": false
+    "headless": false,
+    "include": [
+                "FeedControlMenuActionsShareViaTests/testShareViaOnArticleShareUpdate",
+                "FeedLoadMoreCommentsTrackingTest/testLoadMoreCommentsInFeedDetail()",
+                "FeedSponsoredDownVariantTrackingTest/testTapOnCompanyPictureInDetail(Swift.Int)"
+    ],
+    "exclude": [
+                "FeedShareActorActionTrackingTest/testShareActorDescriptionTrackingInFeedDetail",
+                "FeedAnnotationActionTrackingTest/testMentionAnnotationTrackingInFeedDetail()",
+    ]
 }

--- a/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
@@ -123,58 +123,58 @@
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];// withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
     // When we prevent BPSampleTests from splitting, BPSampleAppFatalErrorTests gets split in two
     want = [[want arrayByAddingObject:@"BPSampleAppFatalErrorTests"] sortedArrayUsingSelector:@selector(compare:)];
-    XCTAssert(bundles.count == app.testBundles.count + 1);
+    XCTAssertEqual(bundles.count, app.testBundles.count + 1);
 
-    XCTAssert([bundles[0].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[1].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[2].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[3].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[4].skipTestIdentifiers count] == 2);
-    XCTAssert([bundles[5].skipTestIdentifiers count] == 3);
+    XCTAssertEqual([bundles[0].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[1].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[2].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 2);
+    XCTAssertEqual([bundles[5].skipTestIdentifiers count], 3);
 
     self.config.numSims = @4;
     self.config.noSplit = nil;
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];
     // 4 unbreakable bundles (too few tests) and the big one broken into 4 bundles
-    XCTAssert(bundles.count == 8);
+    XCTAssertEqual(bundles.count, 8);
     // All we want to test is that we have full coverage
-    XCTAssert([bundles[0].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[1].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[2].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[3].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[4].skipTestIdentifiers count] == 148);
-    XCTAssert([bundles[5].skipTestIdentifiers count] == 148);
-    XCTAssert([bundles[6].skipTestIdentifiers count] == 148);
-    XCTAssert([bundles[7].skipTestIdentifiers count] == 159);
+    XCTAssertEqual([bundles[0].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[1].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[2].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 149);
+    XCTAssertEqual([bundles[5].skipTestIdentifiers count], 149);
+    XCTAssertEqual([bundles[6].skipTestIdentifiers count], 149);
+    XCTAssertEqual([bundles[7].skipTestIdentifiers count], 159);
 
     self.config.numSims = @1;
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];
     // If we pack into just one bundle, we can't have less bundles than the total number of .xctest files.
-    XCTAssert(bundles.count == app.testBundles.count);
+    XCTAssertEqual(bundles.count, app.testBundles.count);
 
     self.config.numSims = @16;
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];
 
-    XCTAssert([bundles[0].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[1].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[2].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[3].skipTestIdentifiers count] == 0);
-    XCTAssert([bundles[4].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[5].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[6].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[7].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[8].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[9].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[10].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[11].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[12].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[13].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[14].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[15].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[16].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[17].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[18].skipTestIdentifiers count] == 188);
-    XCTAssert([bundles[19].skipTestIdentifiers count] == 195);
+    XCTAssertEqual([bundles[0].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[1].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[2].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 0);
+    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[5].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[6].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[7].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[8].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[9].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[10].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[11].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[12].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[13].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[14].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[15].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[16].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[17].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[18].skipTestIdentifiers count], 189);
+    XCTAssertEqual([bundles[19].skipTestIdentifiers count], 195);
 
     NSMutableArray *toRun = [[NSMutableArray alloc] init];
     for (long i = 1; i <= 20; i++) {
@@ -186,7 +186,7 @@
 
     XCTAssertEqual(bundles.count, 4);
     for (BPXCTestFile *bundle in bundles) {
-        XCTAssertEqual(bundle.skipTestIdentifiers.count, 196);
+        XCTAssertEqual(bundle.skipTestIdentifiers.count, 197);
     }
 }
 

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -440,11 +440,21 @@ static NSUUID *sessionID;
         id value = [configDict objectForKey:key];
         for (int i = 0; BPOptions[i].name; i++) {
             if (!strcmp([key UTF8String], BPOptions[i].name)) {
-
                 if (BPOptions[i].kind & BP_LIST && ![value isKindOfClass:[NSArray class]]) {
                     BP_SET_ERROR(error, @"Expected type %@ for key '%@', got %@. Parsing failed.",
                                           [NSArray className], key, [value className]);
                     return NO;
+                }
+                if (BPOptions[i].kind & BP_LIST && [value isKindOfClass:[NSArray class]] && (strcmp(@"include".UTF8String, BPOptions[i].name) || strcmp(@"exclude".UTF8String, BPOptions[i].name))) {
+                    NSMutableArray *testCases = [NSMutableArray new];
+                    for (NSString *testCase in value) {
+                        NSString *trimmedTestName = [BPUtils trimTrailingParanthesesFromTestName:testCase];
+                        if (trimmedTestName == nil) {
+                            continue;
+                        }
+                        [testCases addObject:trimmedTestName];
+                    }
+                    value = [NSArray arrayWithArray:testCases];
                 }
                 if (BPOptions[i].kind & BP_PATH) {
                     NSString *currentPath = [[NSFileManager defaultManager] currentDirectoryPath];

--- a/Source/Shared/BPUtils.h
+++ b/Source/Shared/BPUtils.h
@@ -140,4 +140,10 @@ typedef BOOL (^BPRunBlock)(void);
  */
 + (void)saveDebuggingDiagnostics:(NSString *)outputDirectory;
 
+/*!
+ * @discussion removing trailing parantheses from test names from the extracted symbols
+ * @param testName the name of the test to trim
+ * @return trimmed test name
+ */
++ (NSString *)trimTrailingParanthesesFromTestName:(NSString *)testName;
 @end

--- a/Source/Shared/BPUtils.m
+++ b/Source/Shared/BPUtils.m
@@ -265,4 +265,17 @@ static BOOL quiet = NO;
   [BPUtils runShell:cmd];
 }
 
++ (NSString *)trimTrailingParanthesesFromTestName:(NSString *)testName {
+    // Recently, the extracted symbols from Swift apps began having parenthesis at the end.
+    // Extracting just the name of the test by reading up to the occurrence of the first open brace.
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^\(]+"
+                                                                           options:NSRegularExpressionCaseInsensitive
+                                                                             error:nil];
+    NSArray<NSTextCheckingResult *> *regexMatches = [regex matchesInString:testName options:NSMatchingWithoutAnchoringBounds range:NSMakeRange(0, [testName length])];
+    if (regexMatches.count == 0) {
+        return nil;
+    }
+    return [testName substringWithRange:regexMatches.firstObject.range];
+}
+
 @end

--- a/Source/Shared/BPXCTestFile.m
+++ b/Source/Shared/BPXCTestFile.m
@@ -69,7 +69,11 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
             [allClasses addObject:testClass];
         }
         if (![parts[2] containsString:@"DISABLE"]) {
-            [testClass addTestCase:[[BPTestCase alloc] initWithName:parts[2]]];
+            NSString *trimmedTestName = [BPUtils trimTrailingParanthesesFromTestName:parts[2]];
+            if (trimmedTestName == nil) {
+                continue;
+            }
+            [testClass addTestCase:[[BPTestCase alloc] initWithName:trimmedTestName]];
         }
     }
     if (pclose(p) == -1) {


### PR DESCRIPTION
Test names extracted from the xctestrun file have parantheses at the end which also require specific params to have the same. Adding a regex pattern to trim the test name.