### PR TITLE
Clone template simulator with installed app to reduce tooling time

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -53,6 +53,7 @@
     self.config.junitOutput = NO;
     self.config.testRunnerAppPath = nil;
     self.config.testing_CrashAppOnLaunch = NO;
+    self.config.cloneSimulator = NO;
     NSString *path = @"testScheme.xcscheme";
     self.config.schemePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:path];
     [BPUtils quietMode:[BPUtils isBuildScript]];
@@ -566,6 +567,7 @@
 
     NSURL *preferencesFile = bp.test_simulator.preferencesFile;
 
+    // The plist file need to be a non-default value to test the simulator load the plist file
     NSDictionary *plist = [[NSDictionary alloc] initWithContentsOfURL:preferencesFile];
     XCTAssertEqualObjects(@"en_CH", plist[@"AppleLocale"]);
 

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -296,12 +296,12 @@ void onInterrupt(int ignore) {
     };
 
     handler.onSuccess = ^{
-        if (self.config.cloneSimulator == NO) {
-            // For Bluepill-cli testing, install applicationn as usual
-            NEXT([__self installApplicationWithContext:context]);
-        } else {
-            // launch application directly
+        if (self.config.cloneSimulator) {
+            // launch application directly when clone simulator
             NEXT([__self launchApplicationWithContext:context]);
+        } else {
+            // Install application when test without clone
+            NEXT([__self installApplicationWithContext:context]);
         }
     };
 

--- a/Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimDeviceSet.h
+++ b/Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimDeviceSet.h
@@ -58,9 +58,9 @@
 - (BOOL)deleteDevice:(id)arg1 error:(id *)arg2;
 - (void)deleteDeviceAsync:(id)arg1 completionHandler:(void (^)(NSError *error))arg2;
 - (id)cloneDevice:(id)arg1 name:(id)arg2 error:(id *)arg3;
-- (void)cloneDeviceAsync:(id)arg1 name:(id)arg2 completionQueue:(id)arg3 completionHandler:(CDUnknownBlockType)arg4;
+- (void)cloneDeviceAsync:(id)arg1 name:(id)arg2 completionQueue:(id)arg3 completionHandler:(void (^)(NSError *, SimDevice *))arg4;
 - (void)deleteDeviceAsync:(id)arg1 completionQueue:(id)arg2 completionHandler:(CDUnknownBlockType)arg3;
-- (id)createDeviceWithType:(id)arg1 runtime:(id)arg2 name:(id)arg3 error:(id *)arg4;
+- (SimDevice*)createDeviceWithType:(id)arg1 runtime:(id)arg2 name:(id)arg3 error:(id *)arg4;
 - (void)createDeviceAsyncWithType:(id)arg1 runtime:(id)arg2 name:(id)arg3 completionQueue:(id)arg4 completionHandler:(CDUnknownBlockType)arg5;
 - (void)createDeviceAsyncWithType:(id)arg1 runtime:(id)arg2 name:(id)arg3 completionHandler:(void (^)(NSError *, SimDevice *))arg4;
 - (BOOL)unregisterNotificationHandler:(unsigned long long)arg1 error:(id *)arg2;

--- a/Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimServiceContext.h
+++ b/Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimServiceContext.h
@@ -22,7 +22,7 @@
     BOOL _valid;
     BOOL _initialized;
     long long _connectionType;
-    NSObject<OS_xpc_object> *_serviceConnection;
+    NSObject *_serviceConnection;
     NSObject *_serviceConnectionQueue;
     NSDate *_lastConnectionTime;
     SimProfilesPathMonitor *_profileMonitor;
@@ -39,7 +39,7 @@
 @property(retain, nonatomic) SimProfilesPathMonitor *profileMonitor; // @synthesize profileMonitor=_profileMonitor;
 @property(retain, nonatomic) NSDate *lastConnectionTime; // @synthesize lastConnectionTime=_lastConnectionTime;
 @property(retain, nonatomic) NSObject<OS_dispatch_queue> *serviceConnectionQueue; // @synthesize serviceConnectionQueue=_serviceConnectionQueue;
-@property(retain, nonatomic) NSObject<OS_xpc_object> *serviceConnection; // @synthesize serviceConnection=_serviceConnection;
+@property(retain, nonatomic) NSObject *serviceConnection; // @synthesize serviceConnection=_serviceConnection;
 @property(nonatomic) BOOL valid; // @synthesize valid=_valid;
 @property(retain, nonatomic) NSString *developerDir; // @synthesize developerDir=_developerDir;
 @property(nonatomic) long long connectionType; // @synthesize connectionType=_connectionType;

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -88,7 +88,7 @@
                        }];
 }
 
-- (void) cloneSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
+- (void)cloneSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
     // find simulator template and clone it
     SimDevice *simulatorWithAppInstalled = [self findDeviceWithConfig:self.config andDeviceID:[[NSUUID alloc] initWithUUIDString:self.config.templateSimUDID]];
     [BPUtils printInfo:DEBUGINFO withString:@"clone with simulator template: %@", self.config.templateSimUDID];
@@ -113,7 +113,6 @@
         }
     }];
 }
-
 
 - (NSURL *)preferencesFile {
     return [NSURL fileURLWithPath:kSimulatorLibraryPath relativeToURL:[NSURL fileURLWithPath:self.device.dataPath]];

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -65,14 +65,14 @@
                                     name:deviceName
                        completionHandler:^(NSError *error, SimDevice *device) {
                            __self.device = device;
-                           if (__self.config.screenshotsDirectory) {
-                               __self.screenshotService = [[SimulatorScreenshotService alloc] initWithConfiguration:__self.config forDevice:device];
-                           }
                            if (!__self.device || error) {
                                dispatch_async(dispatch_get_main_queue(), ^{
                                    completion(error);
                                });
                            } else {
+                               if (__self.config.screenshotsDirectory) {
+                                   __self.screenshotService = [[SimulatorScreenshotService alloc] initWithConfiguration:__self.config forDevice:device];
+                               }
                                if (__self.config.simulatorPreferencesFile) {
                                    [__self copySimulatorPreferencesFile:__self.config.simulatorPreferencesFile];
                                }
@@ -90,7 +90,7 @@
 - (void)cloneSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
     // find simulator template and clone it
     SimDevice *simulatorWithAppInstalled = [self findDeviceWithConfig:self.config andDeviceID:[[NSUUID alloc] initWithUUIDString:self.config.templateSimUDID]];
-    [BPUtils printInfo:DEBUGINFO withString:@"clone with simulator template: %@", self.config.templateSimUDID];
+    [BPUtils printInfo:DEBUGINFO withString:@"Clone with simulator template: %@", self.config.templateSimUDID];
     __weak typeof(self) __self = self;
     [deviceSet cloneDeviceAsync:simulatorWithAppInstalled name:deviceName completionQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) completionHandler:^(NSError *error, SimDevice *device){
         __self.device = device;

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -51,11 +51,10 @@
         [BPUtils printInfo:ERROR withString:@"SimDeviceSet failed: %@", [error localizedDescription]];
         return;
     }
-    if (self.config.cloneSimulator == NO) {
-        [self createSimulatorWithDeviceSet:deviceSet withDeviceName:deviceName completion:completion];
-
-    } else {
+    if (self.config.cloneSimulator) {
         [self cloneSimulatorWithDeviceSet:deviceSet withDeviceName:deviceName completion:completion];
+    } else {
+        [self createSimulatorWithDeviceSet:deviceSet withDeviceName:deviceName completion:completion];
     }
 }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -58,7 +58,7 @@
     }
 }
 
-- (void) createSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
+- (void)createSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
     __weak typeof(self) __self = self;
     [deviceSet createDeviceAsyncWithType:self.config.simDeviceType
                                  runtime:self.config.simRuntime

--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -51,18 +51,24 @@
         [BPUtils printInfo:ERROR withString:@"SimDeviceSet failed: %@", [error localizedDescription]];
         return;
     }
+    if (self.config.cloneSimulator == NO) {
+        [self createSimulatorWithDeviceSet:deviceSet withDeviceName:deviceName completion:completion];
 
+    } else {
+        [self cloneSimulatorWithDeviceSet:deviceSet withDeviceName:deviceName completion:completion];
+    }
+}
+
+- (void) createSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
     __weak typeof(self) __self = self;
     [deviceSet createDeviceAsyncWithType:self.config.simDeviceType
                                  runtime:self.config.simRuntime
                                     name:deviceName
                        completionHandler:^(NSError *error, SimDevice *device) {
                            __self.device = device;
-
                            if (__self.config.screenshotsDirectory) {
                                __self.screenshotService = [[SimulatorScreenshotService alloc] initWithConfiguration:__self.config forDevice:device];
                            }
-
                            if (!__self.device || error) {
                                dispatch_async(dispatch_get_main_queue(), ^{
                                    completion(error);
@@ -71,7 +77,6 @@
                                if (__self.config.simulatorPreferencesFile) {
                                    [__self copySimulatorPreferencesFile:__self.config.simulatorPreferencesFile];
                                }
-
                                dispatch_async(dispatch_get_main_queue(), ^{
                                    [__self bootWithCompletion:^(NSError *error) {
                                        dispatch_async(dispatch_get_main_queue(), ^{
@@ -82,6 +87,33 @@
                            }
                        }];
 }
+
+- (void) cloneSimulatorWithDeviceSet:(SimDeviceSet *)deviceSet withDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion {
+    // find simulator template and clone it
+    SimDevice *simulatorWithAppInstalled = [self findDeviceWithConfig:self.config andDeviceID:[[NSUUID alloc] initWithUUIDString:self.config.templateSimUDID]];
+    [BPUtils printInfo:DEBUGINFO withString:@"clone with simulator template: %@", self.config.templateSimUDID];
+    __weak typeof(self) __self = self;
+    [deviceSet cloneDeviceAsync:simulatorWithAppInstalled name:deviceName completionQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) completionHandler:^(NSError *error, SimDevice *device){
+        __self.device = device;
+        if (__self.config.screenshotsDirectory) {
+            __self.screenshotService = [[SimulatorScreenshotService alloc] initWithConfiguration:__self.config forDevice:device];
+        }
+        if (!__self.device || error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(error);
+            });
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [__self bootWithCompletion:^(NSError *error) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        completion(error);
+                    });
+                }];
+            });
+        }
+    }];
+}
+
 
 - (NSURL *)preferencesFile {
     return [NSURL fileURLWithPath:kSimulatorLibraryPath relativeToURL:[NSURL fileURLWithPath:self.device.dataPath]];
@@ -135,7 +167,7 @@
 
 - (void)bootWithCompletion:(void (^)(NSError *error))completion {
     // Now boot it.
-    [BPUtils printInfo:INFO withString:@"Booting a simulator without launching Simulator app"];
+    [BPUtils printInfo:INFO withString:@"Done with create simulator and start booting without launching Simulator app"];
     [self openSimulatorHeadlessWithCompletion:completion];
 }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -157,7 +157,7 @@
     NSString *bundleId = [dic objectForKey:(NSString *)kCFBundleIdentifierKey];
     if (!bundleId) {
         [BPUtils printInfo:ERROR withString:@"Could not extract bundleID: %@", dic];
-        exit(1);
+        return nil;
     }
     return bundleId;
 }

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m
@@ -157,6 +157,7 @@
     NSString *bundleId = [dic objectForKey:(NSString *)kCFBundleIdentifierKey];
     if (!bundleId) {
         [BPUtils printInfo:ERROR withString:@"Could not extract bundleID: %@", dic];
+        exit(1);
     }
     return bundleId;
 }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.h
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.h
@@ -10,12 +10,19 @@
 #import <Foundation/Foundation.h>
 #import "BPXCTestFile.h"
 #import "BPConfiguration.h"
+#import "SimDevice.h"
+#import "SimDeviceType.h"
+#import "SimRuntime.h"
 
 @interface BPRunner : NSObject
 
 @property (nonatomic, strong) BPConfiguration *config;
 @property (nonatomic, strong) NSString *bpExecutable;
 @property (nonatomic, strong) NSMutableArray *nsTaskList;
+@property (nonatomic, strong) SimDeviceType* simDeviceType;
+@property (nonatomic, strong) SimRuntime* simRuntime;
+@property (nonatomic, strong) NSMutableDictionary* testHostForSimUDID;
+@property (nonatomic, strong) NSMutableArray* simDeviceTemplates;
 /*!
  * @discussion get a BPRunnner to run tests
  * @param config the config to run tests
@@ -45,5 +52,8 @@
 - (int)runWithBPXCTestFiles:(NSArray<BPXCTestFile *>*)xcTestFiles;
 
 - (void) interrupt;
+
+- (void)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles;
+- (NSString *)installApplicationwithHost:(NSString *)testHost withError:(NSError *)error;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPRunner.h
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.h
@@ -53,7 +53,7 @@
 
 - (void) interrupt;
 
-- (void)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles;
+- (BOOL)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles;
 - (NSString *)installApplicationwithHost:(NSString *)testHost withError:(NSError *)error;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPRunner.h
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.h
@@ -54,6 +54,6 @@
 - (void) interrupt;
 
 - (BOOL)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles;
-- (NSString *)installApplicationwithHost:(NSString *)testHost withError:(NSError *)error;
+- (NSString *)installApplicationWithHost:(NSString *)testHost withError:(NSError *)error;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -166,6 +166,7 @@ maxprocs(void)
     [self.simDeviceTemplates addObject:simDevice];
     if (!simDevice || error) {
         [BPUtils printInfo:ERROR withString:@"Create simulator failed with error: %@", error];
+        return nil;
     } else {
         [simDevice bootWithOptions:nil error:&error];
         if (error) {
@@ -446,9 +447,11 @@ maxprocs(void)
         //fire & forget, DON'T WAIT
     }
     
-    [BPUtils printInfo:INFO withString:@"All simulators have finished, deleting template simulator.."];
-    [self deleteTemplateSimulator];
-    
+    [BPUtils printInfo:INFO withString:@"All simulators have finished"];
+    if (self.config.cloneSimulator) {
+        [BPUtils printInfo:INFO withString:@"Deleting template simulator.."];
+        [self deleteTemplateSimulator];
+    }
     // Process the generated report and create 1 single junit xml file.
     if (app) {
         [app terminate];

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -91,7 +91,7 @@ maxprocs(void)
     NSError *error = nil;
     if (self.config.appBundlePath) {
         // This is for integration testing for bluepill and bluepill-cli when we assign self.config.appBundlePath
-        simulatorUDIDString = [self installApplicationwithHost:self.config.appBundlePath withError:error];
+        simulatorUDIDString = [self installApplicationWithHost:self.config.appBundlePath withError:error];
         if (!simulatorUDIDString || !error) {
             [BPUtils printInfo:ERROR withString:@"Create simualtor and install application failed with error: %@", error];
             return FALSE;
@@ -109,7 +109,7 @@ maxprocs(void)
         }
         for (NSString *appPath in hostBundles) {
             NSError *error = nil;
-            simulatorUDIDString = [self installApplicationwithHost:appPath withError:error];
+            simulatorUDIDString = [self installApplicationWithHost:appPath withError:error];
             if (!simulatorUDIDString || !error) {
                 [BPUtils printInfo:ERROR withString:@"Created simulator template and innstall applicationn failed with error: %@", error];
                 return FALSE;
@@ -121,7 +121,7 @@ maxprocs(void)
     return TRUE;
 }
 
-- (NSString *)installApplicationwithHost:(NSString *)testHost withError:(NSError *)error {
+- (NSString *)installApplicationWithHost:(NSString *)testHost withError:(NSError *)error {
     SimServiceContext *sc = [SimServiceContext sharedServiceContextForDeveloperDir:self.config.xcodePath error:&error];
     if (!sc) {
         [BPUtils printInfo:ERROR withString:[NSString stringWithFormat:@"SimServiceContext failed: %@", [error localizedDescription]]];

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -96,6 +96,9 @@ int main(int argc, char * argv[]) {
         BPConfiguration *normalizedConfig = [BPUtils normalizeConfiguration:config withTestFiles:app.testBundles];
         // start a runner and let it fly
         BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig withBpPath:nil];
+        if (config.cloneSimulator) {
+            [runner createSimulatorAndInstallAppWithBundles:app.testBundles];
+        }
         exit([runner runWithBPXCTestFiles:app.testBundles]);
     }
     return 0;

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -96,9 +96,6 @@ int main(int argc, char * argv[]) {
         BPConfiguration *normalizedConfig = [BPUtils normalizeConfiguration:config withTestFiles:app.testBundles];
         // start a runner and let it fly
         BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig withBpPath:nil];
-        if (config.cloneSimulator) {
-            [runner createSimulatorAndInstallAppWithBundles:app.testBundles];
-        }
         exit([runner runWithBPXCTestFiles:app.testBundles]);
     }
     return 0;

--- a/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
+++ b/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
@@ -14,6 +14,22 @@
 		7A6672C01E0B0BB400AC6778 /* BPXCTestFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FB8CA1DF89A370073F268 /* BPXCTestFile.m */; };
 		7A6672C11E0B0BBC00AC6778 /* BPTestClass.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FB8DC1DF89B1A0073F268 /* BPTestClass.m */; };
 		7A6672C21E0B0BBF00AC6778 /* BPTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FB8DA1DF89B1A0073F268 /* BPTestCase.m */; };
+		B3199F672121E89900787BF6 /* SimDevice.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F662121E89800787BF6 /* SimDevice.h */; };
+		B3199F692121E8AA00787BF6 /* SimServiceContext.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F682121E8AA00787BF6 /* SimServiceContext.h */; };
+		B3199F6B2121E8BB00787BF6 /* SimDeviceSet.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6A2121E8BB00787BF6 /* SimDeviceSet.h */; };
+		B3199F6D2121E8D200787BF6 /* SimulatorHelper.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6C2121E8D200787BF6 /* SimulatorHelper.h */; };
+		B3199F6F2121E8E800787BF6 /* SimulatorHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6E2121E8E800787BF6 /* SimulatorHelper.m */; };
+		B3199F712121E91200787BF6 /* XCTestConfiguration.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F702121E91200787BF6 /* XCTestConfiguration.h */; };
+		B3199F722121E99F00787BF6 /* XCTestConfiguration.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F702121E91200787BF6 /* XCTestConfiguration.h */; };
+		B3199F732121E99F00787BF6 /* SimulatorHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6E2121E8E800787BF6 /* SimulatorHelper.m */; };
+		B3199F742121E99F00787BF6 /* SimulatorHelper.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6C2121E8D200787BF6 /* SimulatorHelper.h */; };
+		B3199F752121E99F00787BF6 /* SimDeviceSet.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F6A2121E8BB00787BF6 /* SimDeviceSet.h */; };
+		B3199F762121E99F00787BF6 /* SimServiceContext.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F682121E8AA00787BF6 /* SimServiceContext.h */; };
+		B3199F772121E99F00787BF6 /* SimDevice.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F662121E89800787BF6 /* SimDevice.h */; };
+		B3199F7C2121EC9200787BF6 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3199F792121EA5E00787BF6 /* CoreSimulator.framework */; };
+		B3199F802121FABC00787BF6 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3199F7F2121FABC00787BF6 /* XCTest.framework */; };
+		B3199F812122019000787BF6 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3199F792121EA5E00787BF6 /* CoreSimulator.framework */; };
+		B3199F842122231000787BF6 /* SimRuntime.h in Sources */ = {isa = PBXBuildFile; fileRef = B3199F832122230D00787BF6 /* SimRuntime.h */; };
 		BA1809E91DBA8FC300D7D130 /* BPRunnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA1809E81DBA8FC300D7D130 /* BPRunnerTests.m */; };
 		BA1809EB1DBA910400D7D130 /* BPAppTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA1809EA1DBA910400D7D130 /* BPAppTests.m */; };
 		BA1809EE1DBA929600D7D130 /* BPTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = BA1809ED1DBA929600D7D130 /* BPTestHelper.m */; };
@@ -62,6 +78,17 @@
 		7A4FB8DA1DF89B1A0073F268 /* BPTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPTestCase.m; sourceTree = "<group>"; };
 		7A4FB8DB1DF89B1A0073F268 /* BPTestClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPTestClass.h; sourceTree = "<group>"; };
 		7A4FB8DC1DF89B1A0073F268 /* BPTestClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPTestClass.m; sourceTree = "<group>"; };
+		B3199F662121E89800787BF6 /* SimDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimDevice.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimDevice.h"; sourceTree = "<group>"; };
+		B3199F682121E8AA00787BF6 /* SimServiceContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimServiceContext.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimServiceContext.h"; sourceTree = "<group>"; };
+		B3199F6A2121E8BB00787BF6 /* SimDeviceSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimDeviceSet.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimDeviceSet.h"; sourceTree = "<group>"; };
+		B3199F6C2121E8D200787BF6 /* SimulatorHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimulatorHelper.h; path = "../Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.h"; sourceTree = "<group>"; };
+		B3199F6E2121E8E800787BF6 /* SimulatorHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SimulatorHelper.m; path = "../Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.m"; sourceTree = "<group>"; };
+		B3199F702121E91200787BF6 /* XCTestConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = XCTestConfiguration.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/XCTest/XCTestConfiguration.h"; sourceTree = "<group>"; };
+		B3199F792121EA5E00787BF6 /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = ../../../../../Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<group>"; };
+		B3199F7D2121FAB000787BF6 /* Xcode.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; name = Xcode.app; path = ../../../../../Applications/xcode9.4/Xcode.app; sourceTree = "<group>"; };
+		B3199F7F2121FABC00787BF6 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		B3199F822122219D00787BF6 /* SimDeviceType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimDeviceType.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimDeviceType.h"; sourceTree = "<group>"; };
+		B3199F832122230D00787BF6 /* SimRuntime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimRuntime.h; path = "../Bluepill-cli/Bluepill-cli/PrivateHeaders/CoreSimulator/SimRuntime.h"; sourceTree = "<group>"; };
 		BA1809E01DBA8FB100D7D130 /* BluepillRunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BluepillRunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA1809E41DBA8FB100D7D130 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA1809E81DBA8FC300D7D130 /* BPRunnerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BPRunnerTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -101,6 +128,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3199F812122019000787BF6 /* CoreSimulator.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,6 +136,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3199F7C2121EC9200787BF6 /* CoreSimulator.framework in Frameworks */,
+				B3199F802121FABC00787BF6 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -132,6 +162,16 @@
 			);
 			name = Shared;
 			path = ../../Source/Shared;
+			sourceTree = "<group>";
+		};
+		B3199F782121EA5E00787BF6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B3199F7F2121FABC00787BF6 /* XCTest.framework */,
+				B3199F7D2121FAB000787BF6 /* Xcode.app */,
+				B3199F792121EA5E00787BF6 /* CoreSimulator.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		BA1809E11DBA8FB100D7D130 /* BluepillRunnerTests */ = {
@@ -198,10 +238,19 @@
 		BAEF4B2B1DAC539400E68294 = {
 			isa = PBXGroup;
 			children = (
+				B3199F832122230D00787BF6 /* SimRuntime.h */,
+				B3199F822122219D00787BF6 /* SimDeviceType.h */,
+				B3199F702121E91200787BF6 /* XCTestConfiguration.h */,
+				B3199F6E2121E8E800787BF6 /* SimulatorHelper.m */,
+				B3199F6C2121E8D200787BF6 /* SimulatorHelper.h */,
+				B3199F6A2121E8BB00787BF6 /* SimDeviceSet.h */,
+				B3199F682121E8AA00787BF6 /* SimServiceContext.h */,
+				B3199F662121E89800787BF6 /* SimDevice.h */,
 				BAFCCA361E33595F00E33C31 /* bluepill.xcconfig */,
 				BAEF4B361DAC539400E68294 /* Bluepill */,
 				BA1809E11DBA8FB100D7D130 /* BluepillRunnerTests */,
 				BAEF4B351DAC539400E68294 /* Products */,
+				B3199F782121EA5E00787BF6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -348,6 +397,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3199F722121E99F00787BF6 /* XCTestConfiguration.h in Sources */,
+				B3199F732121E99F00787BF6 /* SimulatorHelper.m in Sources */,
+				B3199F742121E99F00787BF6 /* SimulatorHelper.h in Sources */,
+				B3199F752121E99F00787BF6 /* SimDeviceSet.h in Sources */,
+				B3199F762121E99F00787BF6 /* SimServiceContext.h in Sources */,
+				B3199F772121E99F00787BF6 /* SimDevice.h in Sources */,
 				C42A401E1E31865D00B83FCC /* BPConstants.m in Sources */,
 				BA1809E91DBA8FC300D7D130 /* BPRunnerTests.m in Sources */,
 				BA1809FB1DBA949600D7D130 /* BPPacker.m in Sources */,
@@ -372,6 +427,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3199F842122231000787BF6 /* SimRuntime.h in Sources */,
+				B3199F712121E91200787BF6 /* XCTestConfiguration.h in Sources */,
+				B3199F6F2121E8E800787BF6 /* SimulatorHelper.m in Sources */,
+				B3199F6D2121E8D200787BF6 /* SimulatorHelper.h in Sources */,
+				B3199F6B2121E8BB00787BF6 /* SimDeviceSet.h in Sources */,
+				B3199F692121E8AA00787BF6 /* SimServiceContext.h in Sources */,
+				B3199F672121E89900787BF6 /* SimDevice.h in Sources */,
 				C4FD8C581DB6E09B000ED28C /* BPPacker.m in Sources */,
 				7A4FB8DD1DF89B1A0073F268 /* BPTestCase.m in Sources */,
 				BAEF4B381DAC539400E68294 /* main.m in Sources */,
@@ -394,6 +456,14 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
+					"$(DEVELOPER_DIR)/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+					"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)",
+					"$(PRIVATE_FRAMEWORKS_DIR)",
+				);
 				INFOPLIST_FILE = BluepillRunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -408,6 +478,14 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
+					"$(DEVELOPER_DIR)/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+					"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)",
+					"$(PRIVATE_FRAMEWORKS_DIR)",
+				);
 				INFOPLIST_FILE = BluepillRunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -449,6 +527,8 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPER_PRIVATE_FRAMEWORKS_DIR = "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks";
+				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -468,6 +548,8 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRIVATE_FRAMEWORKS_DIR = "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks";
+				"PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -504,6 +586,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -516,6 +599,8 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRIVATE_FRAMEWORKS_DIR = "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks";
+				"PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -525,6 +610,20 @@
 			buildSettings = {
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
+					"$(DEVELOPER_DIR)/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+					"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)",
+					"$(PRIVATE_FRAMEWORKS_DIR)",
+				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					CoreSimulator,
+					"-weak_framework",
+					XCTest,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -534,6 +633,14 @@
 			buildSettings = {
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
+					"$(DEVELOPER_DIR)/Library/PrivateFrameworks",
+					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+					"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)",
+					"$(PRIVATE_FRAMEWORKS_DIR)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -63,9 +63,6 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -82,9 +79,6 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -100,17 +94,11 @@
     self.config.testBundlePath = [BPTestHelper sampleAppUITestBundlePath];
     self.config.testRunnerAppPath = [BPTestHelper sampleAppPath];
     self.config.appBundlePath = [BPTestHelper sampleAppUITestRunnerPath];
-
-
     NSError *err;
     BPApp *app = [BPApp appWithConfig:self.config
                             withError:&err];
-
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -128,9 +116,6 @@
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 7);
     XCTAssert(rc != 0); // this runs tests that fail
@@ -145,9 +130,6 @@
                             withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -161,12 +143,8 @@
     NSError *err;
     BPApp *app = [BPApp appWithConfig:self.config
                             withError:&err];
-
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
-    if (self.config.cloneSimulator == YES) {
-        [runner createSimulatorAndInstallAppWithBundles:nil];
-    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -42,6 +42,7 @@
     self.config.jsonOutput = NO;
     self.config.headlessMode = YES;
     self.config.junitOutput = NO;
+    self.config.cloneSimulator = NO;
     NSString *path = @"testScheme.xcscheme";
     self.config.schemePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:path];
     [BPUtils enableDebugOutput:![BPUtils isBuildScript]];
@@ -62,6 +63,9 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -78,6 +82,9 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -101,6 +108,9 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -118,6 +128,9 @@
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 7);
     XCTAssert(rc != 0); // this runs tests that fail
@@ -132,6 +145,9 @@
                             withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -148,6 +164,9 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    if (self.config.cloneSimulator == YES) {
+        [runner createSimulatorAndInstallAppWithBundles:nil];
+    }
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);

--- a/Bluepill-runner/bluepill.xcconfig
+++ b/Bluepill-runner/bluepill.xcconfig
@@ -8,3 +8,11 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #include "../Configurations/common.xcconfig"
+DEVELOPER_PRIVATE_FRAMEWORKS_DIR = $(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks
+//DEVELOPER_FRAMEWORKS = $(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks
+//SHARED_FRAMEWORKS_DIR = $(DEVELOPER_DIR)/Contents/SharedFrameworks
+PRIVATE_FRAMEWORKS_DIR = $(DEVELOPER_DIR)/Library/PrivateFrameworks
+
+FRAMEWORK_SEARCH_PATHS = "$(PRIVATE_FRAMEWORKS_DIR)" "$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)" "$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks" "$(DEVELOPER_DIR)/Library/PrivateFrameworks" "$(DEVELOPER_DIR)/../SharedFrameworks" "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks"
+
+OTHER_LDFLAGS = -weak_framework CoreSimulator -weak_framework XCTest

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSString *screenshotsDirectory;
 @property (nonatomic, strong) NSString *simulatorPreferencesFile;
 @property (nonatomic) BOOL headlessMode;
+@property (nonatomic) BOOL cloneSimulator;
 @property (nonatomic, strong) NSNumber *numSims;
 @property (nonatomic) BOOL listTestsOnly;
 @property (nonatomic) BOOL quiet;
@@ -98,6 +99,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 
 // Generated fields
 @property (nonatomic, strong) NSString *xcodePath;
+@property (nonatomic, strong) NSString *templateSimUDID;
 
 #ifdef BP_USE_PRIVATE_FRAMEWORKS
 @property (nonatomic, strong) SimDeviceType *simDeviceType;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -51,7 +51,7 @@ struct BPOptions {
     // Optional argument
     {'d', "device", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_DEVICE_TYPE, BP_VALUE, "deviceType",
         "On which device to run the app."},
-    {'U', "templateSimUDID", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "templateSimUDID",
+    {'U', "templateSimUDID", BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "templateSimUDID",
         "template simulator with app installed"},
     {'c', "config", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "configFile",
         "Read options from the specified configuration file instead of the command line"},

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -51,6 +51,8 @@ struct BPOptions {
     // Optional argument
     {'d', "device", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_DEVICE_TYPE, BP_VALUE, "deviceType",
         "On which device to run the app."},
+    {'U', "templateSimUDID", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "templateSimUDID",
+        "template simulator with app installed"},
     {'c', "config", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "configFile",
         "Read options from the specified configuration file instead of the command line"},
     {'t', "test-bundle-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
@@ -91,6 +93,8 @@ struct BPOptions {
         "Paths to the images to be uploaded."},
 
     // options with no argument
+    {'L', "clone-simulator", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "cloneSimulator",
+        "Run test with clone-simulator"},
     {'H', "headless", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "headlessMode",
         "Run in headless mode (no GUI)."},
     {'J', "json-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "jsonOutput",


### PR DESCRIPTION
Install application is an expensive process (~2min in some cases). For testing with multi sim, this is more expensive as we do is multiple times. We can save time by first create a sim and install the test host, then clone it multiple times for testing.