### PR TITLE
Fix Test Report Issue

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -47,7 +47,9 @@
                 NSXMLDocument *doc = [[NSXMLDocument alloc] initWithContentsOfURL:url options:0 error:&error];
                 if (error) {
                     [BPUtils printInfo:ERROR withString:@"Failed to parse %@: %@", url, error.localizedDescription];
-                    return;
+                    // When app crash before test start, it can result in empty xml file
+                    // Test results from other BP workers should continue to parse
+                    continue;
                 }
 
                 // Don't withhold the parent object.


### PR DESCRIPTION
When there is a BP worker did not do any test, it will result in empy xml file. In that case, it will result in exmpy final test report. This pull request is to fix this issue.