### PR TITLE
extend XCTIDEConnectionTimeout

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -432,7 +432,8 @@
     // These are appended by Xcode so we do that here.
     [commandLineArgs addObjectsFromArray:@[
                                            @"-NSTreatUnknownArgumentsAsOpen", @"NO",
-                                           @"-ApplePersistenceIgnoreState", @"YES"
+                                           @"-ApplePersistenceIgnoreState", @"YES",
+                                           @"-XCTIDEConnectionTimeout", @180
                                            ]];
 
     argsAndEnv[@"args"] = [commandLineArgs copy];


### PR DESCRIPTION
Xcode 10 is slower to establish control session. This is to avoid "timed out failure with IDE session ready for test plan"