### PR TITLE
Start a fresh retry after launch app failed

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -409,7 +409,7 @@ void onInterrupt(int ignore) {
         if (--__self.maxLaunchTries > 0) {
             [BPUtils printInfo:INFO withString:@"Relaunching the simulator due to a BAD STATE"];
             context.runner = [__self createSimulatorRunnerWithContext:context];
-            NEXT([__self createSimulatorWithContext:context]);
+            NEXT([__self launchApplicationWithContext:context]);
         } else {
             NEXT([__self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed]);
         }
@@ -420,7 +420,8 @@ void onInterrupt(int ignore) {
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
         [[BPStats sharedStats] endTimer:stepName];
         [BPUtils printInfo:FAILED withString:@"Timeout: %@", stepName];
-        NEXT([__self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed]);
+        [BPUtils printInfo:INFO withString:@"Saving Diagnostics for Debugging"];
+        [BPUtils saveDebuggingDiagnostics:context.config.outputDirectory];
     };
 
     [context.runner launchApplicationAndExecuteTestsWithParser:context.parser andCompletion:handler.defaultHandlerBlock];

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -48,7 +48,6 @@ void onInterrupt(int ignore) {
 
 @property (nonatomic, assign) NSInteger maxCreateTries;
 @property (nonatomic, assign) NSInteger maxInstallTries;
-@property (nonatomic, assign) NSInteger maxLaunchTries;
 
 @end
 
@@ -247,8 +246,6 @@ void onInterrupt(int ignore) {
 
     // Set up retry counts.
     self.maxCreateTries = [self.config.maxCreateTries integerValue];
-    self.maxInstallTries = [self.config.maxInstallTries integerValue];
-    self.maxLaunchTries = [self.config.maxLaunchTries integerValue];
     
     if (context.config.deleteSimUDID) {
         NEXT([self deleteSimulatorOnlyTaskWithContext:context]);

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -406,12 +406,7 @@ void onInterrupt(int ignore) {
     handler.onError = ^(NSError *error) {
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
         [BPUtils printInfo:ERROR withString:@"Could not launch app and tests: %@", [error localizedDescription]];
-        if (--__self.maxLaunchTries > 0) {
-            [BPUtils printInfo:INFO withString:@"Relaunching the app due to a BAD STATE"];
-            NEXT([__self launchApplicationWithContext:context]);
-        } else {
-            NEXT([__self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed]);
-        }
+        NEXT([__self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed]);
     };
 
     handler.onTimeout = ^{

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -420,8 +420,6 @@ void onInterrupt(int ignore) {
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
         [[BPStats sharedStats] endTimer:stepName];
         [BPUtils printInfo:FAILED withString:@"Timeout: %@", stepName];
-        [BPUtils printInfo:INFO withString:@"Saving Diagnostics for Debugging"];
-        [BPUtils saveDebuggingDiagnostics:context.config.outputDirectory];
     };
 
     [context.runner launchApplicationAndExecuteTestsWithParser:context.parser andCompletion:handler.defaultHandlerBlock];

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -246,6 +246,7 @@ void onInterrupt(int ignore) {
 
     // Set up retry counts.
     self.maxCreateTries = [self.config.maxCreateTries integerValue];
+    self.maxInstallTries = [self.config.maxInstallTries integerValue];
     
     if (context.config.deleteSimUDID) {
         NEXT([self deleteSimulatorOnlyTaskWithContext:context]);

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -407,8 +407,7 @@ void onInterrupt(int ignore) {
         [[BPStats sharedStats] endTimer:RUN_TESTS(context.attemptNumber)];
         [BPUtils printInfo:ERROR withString:@"Could not launch app and tests: %@", [error localizedDescription]];
         if (--__self.maxLaunchTries > 0) {
-            [BPUtils printInfo:INFO withString:@"Relaunching the simulator due to a BAD STATE"];
-            context.runner = [__self createSimulatorRunnerWithContext:context];
+            [BPUtils printInfo:INFO withString:@"Relaunching the app due to a BAD STATE"];
             NEXT([__self launchApplicationWithContext:context]);
         } else {
             NEXT([__self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed]);

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -79,7 +79,6 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic) BOOL verboseLogging;
 @property (nonatomic, strong) NSNumber *maxCreateTries;
 @property (nonatomic, strong) NSNumber *maxInstallTries;
-@property (nonatomic, strong) NSNumber *maxLaunchTries;
 @property (nonatomic, strong) NSNumber *createTimeout;
 @property (nonatomic, strong) NSNumber *launchTimeout;
 @property (nonatomic, strong) NSNumber *deleteTimeout;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -123,8 +123,6 @@ struct BPOptions {
         "The maximum number of times to attempt to create a simulator before failing a test attempt"},
     {354, "max-sim-install-attempts", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxInstallTries",
         "The maximum number of times to attempt to install the test app into a simulator before failing a test attempt"},
-    {355, "max-sim-launch-attempts", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxLaunchTries",
-        "The maximum number of times to attempt to launch the test app in a simulator before failing a test attempt"},
     {356, "create-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "createTimeout",
         "The maximum amount of time, in seconds, to wait before giving up on simulator creation"},
     {357, "launch-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "launchTimeout",


### PR DESCRIPTION
`handler.onTimeout` is not working properly to retry lanuch app because it does not terminate the current thread. If it retries while the original thread succeeds with launch, it will cause wrong sim device status as there are two threads that are trying to continue to run test.