### PR TITLE
Added config options for preserving retry xml log

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -213,6 +213,28 @@
     [self assertGotReport:junitReportPath isEqualToWantReport:expectedFilePath];
 }
 
+- (void)testSaveRetryXml {
+    NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppSaveRetryXmlTestsSetTempDir", tempDir] withError:&error];
+
+    self.config.outputDirectory = outputDir;
+    self.config.junitOutput = YES;
+    self.config.errorRetriesCount = @1;
+    self.config.failureTolerance = @1;
+    self.config.onlyRetryFailed = YES;
+    self.config.saveRetryXml = YES;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusAppCrashed);
+
+    NSString *junitReportPath = [outputDir stringByAppendingPathComponent:@"failures/TEST-BPSampleAppCrashingTests-failure-1-results.xml"];
+    NSString *expectedFilePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"save_retry.xml"];
+    [self assertGotReport:junitReportPath isEqualToWantReport:expectedFilePath];
+}
+
 - (void)testReportWithAppCrashingAndRetryOnlyFailedTestsSet {
     NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
@@ -225,10 +247,10 @@
     self.config.errorRetriesCount = @1;
     self.config.failureTolerance = @1;
     self.config.onlyRetryFailed = YES;
-
+    
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssertTrue(exitCode == BPExitStatusAppCrashed);
-
+    
     NSString *junitReportPath = [outputDir stringByAppendingPathComponent:@"TEST-BPSampleAppCrashingTests-results.xml"];
     NSLog(@"JUnit file: %@", junitReportPath);
     NSString *expectedFilePath = [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"crash_tests_with_retry.xml"];

--- a/Bluepill-cli/BPInstanceTests/Resource Files/save_retry.xml
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/save_retry.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="All tests" tests="0" failures="0" errors="0" time="0.000000">
+    <testsuite tests="0" failures="0" errors="0" time="0.937023" timestamp="2018-12-06T15:35:23GMT-08:00" name="BPSampleAppCrashingTests.xctest">
+        <testsuite tests="0" failures="0" errors="0" time="0.936033" timestamp="2018-12-06T15:35:23GMT-08:00" name="BPSampleAppCrashingTests">
+            <testcase classname="BPSampleAppCrashingTests" name="testAppCrash0" time="0.001000">
+            </testcase>
+            <testcase classname="BPSampleAppCrashingTests" name="testAppCrash1" time="0.924852">
+                <failure type="Failure" message="App Crashed">
+                    Unknown File:0
+                </failure>
+                <system-out>
+                    XCTestOutputBarrier
+                </system-out>
+            </testcase>
+        </testsuite>
+    </testsuite>
+</testsuites>
+

--- a/Bluepill-cli/Bluepill-cli.xcodeproj/project.pbxproj
+++ b/Bluepill-cli/Bluepill-cli.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		C469B1581FE1A420002246BF /* crash_tests_with_retry.xml in Resources */ = {isa = PBXBuildFile; fileRef = C469B1571FE1A41F002246BF /* crash_tests_with_retry.xml */; };
 		C4FAC2951E5E67ED00ACC5D9 /* testConfig-busted.json in Resources */ = {isa = PBXBuildFile; fileRef = C4FAC2941E5E67ED00ACC5D9 /* testConfig-busted.json */; };
 		C94DE0BB4360016D3D3061D9 /* simulator-preferences.plist in Resources */ = {isa = PBXBuildFile; fileRef = C94DEF7F8BCA7AB3C9114467 /* simulator-preferences.plist */; };
+		E6056B9D21BAF6D300C6C31B /* save_retry.xml in Resources */ = {isa = PBXBuildFile; fileRef = E6056B9C21BAF6D300C6C31B /* save_retry.xml */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -318,6 +319,7 @@
 		C48AE3821FBCC59D00997BA0 /* BPVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPVersion.h; sourceTree = SOURCE_ROOT; };
 		C4FAC2941E5E67ED00ACC5D9 /* testConfig-busted.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "testConfig-busted.json"; sourceTree = "<group>"; };
 		C94DEF7F8BCA7AB3C9114467 /* simulator-preferences.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = "simulator-preferences.plist"; sourceTree = "<group>"; };
+		E6056B9C21BAF6D300C6C31B /* save_retry.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = save_retry.xml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -493,6 +495,7 @@
 				BA4BCFD01DC4888800592FA4 /* hanging_tests.xml */,
 				BA0C554C1DDAE241009E1377 /* failure_retry_report.xml */,
 				BA4BCFAB1DC3FA3D00592FA4 /* crash_tests.xml */,
+				E6056B9C21BAF6D300C6C31B /* save_retry.xml */,
 				BA4800E91DC2C74600026972 /* BPAppNegativeTests-results.xml */,
 				BA180A0B1DBB011200D7D130 /* testConfig.json */,
 				BA180A131DBB088100D7D130 /* testScheme.xcscheme */,
@@ -880,6 +883,7 @@
 				BA0C554D1DDAE241009E1377 /* failure_retry_report.xml in Resources */,
 				BA9C2DE01DD84A72007CB967 /* fatal_tests.xml in Resources */,
 				7A4D7A831DDA5FEA001E085D /* parse_crash.log in Resources */,
+				E6056B9D21BAF6D300C6C31B /* save_retry.xml in Resources */,
 				BA4BCFAC1DC3FA3D00592FA4 /* crash_tests.xml in Resources */,
 				C469B1581FE1A420002246BF /* crash_tests_with_retry.xml in Resources */,
 				7A4FB8E81DFB66980073F268 /* error_only_crash.log in Resources */,

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -526,9 +526,9 @@ void onInterrupt(int ignore) {
                     [fileManager createDirectoryAtPath:retryDir withIntermediateDirectories:YES attributes:nil error:NULL];
 
                     NSArray *directoryContent  = [fileManager contentsOfDirectoryAtPath:retryDir error:nil];
-                    NSUInteger numberOfFileInFolder = [directoryContent count] + 1;
+                    NSUInteger numberOfFilesInFolder = [directoryContent count] + 1;
                     NSString *copyFileName = [NSString stringWithFormat:@"TEST-%@-failure-%lu-results.xml",
-                                              [[context.config.testBundlePath lastPathComponent] stringByDeletingPathExtension], numberOfFileInFolder];
+                                              [[context.config.testBundlePath lastPathComponent] stringByDeletingPathExtension], numberOfFilesInFolder];
                     NSString *copyFilePath = [retryDir stringByAppendingPathComponent:copyFileName];
                     
                     [fileManager copyItemAtURL:[NSURL fileURLWithPath:outputFile] toURL:[NSURL fileURLWithPath:copyFilePath] error:nil];

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -518,6 +518,22 @@ void onInterrupt(int ignore) {
                 NSString *fileName = [NSString stringWithFormat:@"TEST-%@-results.xml",
                                       [[context.config.testBundlePath lastPathComponent] stringByDeletingPathExtension]];
                 NSString *outputFile = [context.config.outputDirectory stringByAppendingPathComponent:fileName];
+                
+                NSFileManager *fileManager = [NSFileManager defaultManager];
+                if (context.config.saveRetryXml && [fileManager isReadableFileAtPath:outputFile]) {
+                    NSString *retryDir = [context.config.outputDirectory stringByAppendingPathComponent:@"failures/"];
+                    
+                    [fileManager createDirectoryAtPath:retryDir withIntermediateDirectories:YES attributes:nil error:NULL];
+
+                    NSArray *directoryContent  = [fileManager contentsOfDirectoryAtPath:retryDir error:nil];
+                    NSUInteger numberOfFileInFolder = [directoryContent count] + 1;
+                    NSString *copyFileName = [NSString stringWithFormat:@"TEST-%@-failure-%lu-results.xml",
+                                              [[context.config.testBundlePath lastPathComponent] stringByDeletingPathExtension], numberOfFileInFolder];
+                    NSString *copyFilePath = [retryDir stringByAppendingPathComponent:copyFileName];
+                    
+                    [fileManager copyItemAtURL:[NSURL fileURLWithPath:outputFile] toURL:[NSURL fileURLWithPath:copyFilePath] error:nil];
+                }
+                
                 junitLog = [[BPWriter alloc] initWithDestination:BPWriterDestinationFile andPath:outputFile];
             } else {
                 junitLog = [[BPWriter alloc] initWithDestination:BPWriterDestinationStdout];

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -17,7 +17,7 @@
  * @param finalReportPath the path to save the final report
  */
 + (void)collectReportsFromPath:(NSString *)reportsPath
+                   applyXQuery:(NSString *)XQuery
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
                   outputAtPath:(NSString *)finalReportPath;
-
 @end

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -20,4 +20,5 @@
                    applyXQuery:(NSString *)XQuery
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
                   outputAtPath:(NSString *)finalReportPath;
+
 @end

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -17,8 +17,8 @@
  * @param finalReportPath the path to save the final report
  */
 + (void)collectReportsFromPath:(NSString *)reportsPath
-                   applyXQuery:(NSString *)XQuery
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
-                  outputAtPath:(NSString *)finalReportPath;
+                   applyXQuery:(NSString *)XQuery
+                  withOutputAtPath:(NSString *)finalReportPath;
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -13,9 +13,9 @@
 @implementation BPReportCollector
 
 + (void)collectReportsFromPath:(NSString *)reportsPath
-                   applyXQuery:(NSString *)XQuery
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
-                  outputAtPath:(NSString *)finalReportPath {
+                   applyXQuery:(NSString *)XQuery
+                  withOutputAtPath:(NSString *)finalReportPath {
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
     NSURL *directoryURL = [NSURL fileURLWithPath:reportsPath isDirectory:YES];
@@ -63,6 +63,7 @@
                 
                 NSArray *testsuiteNodes = nil;
                 if (XQuery) {
+                    // <testsuites> refer to each .xctest run, while the first <testsuite> refers to the bundle and the second <testsuite> refers to each file in that bundle. The provided XQuery string will filter down to specific testcases based on what they contain.
                     testsuiteNodes = [doc objectsForXQuery:[NSString stringWithFormat:@".//testsuites/testsuite/testsuite/%@/../..", XQuery] error:&error];
                     for (NSXMLElement *element in testsuiteNodes) {
                         totalTests += [[[element attributeForName:@"tests"] stringValue] integerValue];

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -61,7 +61,7 @@
                     continue;
                 }
                 
-                NSArray *testsuiteNodes = nil;g
+                NSArray *testsuiteNodes = nil;
                 if (XQuery) {
                     testsuiteNodes = [doc objectsForXQuery:[NSString stringWithFormat:@".//testsuites/testsuite/testsuite/%@/../..", XQuery] error:&error];
                     for (NSXMLElement *element in testsuiteNodes) {

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -43,7 +43,7 @@
             fprintf(stderr, "Failed to get resource from url %s", [[url absoluteString] UTF8String]);
         }
         else if (![isDirectory boolValue]) {
-            if ([[url lastPathComponent] hasSuffix:@"results.xml"]) {
+            if ([[url pathExtension] isEqualToString:@"xml"]) {
                 // Skipping over the failure logs for the total report
                 // so it only contains successes to maintain existing functionality
                 // todo: These logs actually need to be parsed for just the

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -61,8 +61,7 @@
                     continue;
                 }
                 
-                NSArray *testsuiteNodes = nil;
-                // testcase/error, testcase/failure
+                NSArray *testsuiteNodes = nil;g
                 if (XQuery) {
                     testsuiteNodes = [doc objectsForXQuery:[NSString stringWithFormat:@".//testsuites/testsuite/testsuite/%@/../..", XQuery] error:&error];
                     for (NSXMLElement *element in testsuiteNodes) {

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -106,5 +106,5 @@
     NSData *xmlData = [xmlRequest XMLDataWithOptions:NSXMLDocumentIncludeContentTypeDeclaration];
     [xmlData writeToFile:finalReportPath atomically:YES];
 }
-@end
 
+@end

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -313,23 +313,26 @@ maxprocs(void)
         if ([fm fileExistsAtPath:outputPath]) {
             [fm removeItemAtPath:outputPath error:nil];
         }
-        [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:nil onReportCollected:^(NSURL *fileUrl) {
+        [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {
 //            NSError *error;
 //            NSFileManager *fm = [NSFileManager new];
 //            [fm removeItemAtURL:fileUrl error:&error];
-        } outputAtPath:outputPath];
+        } applyXQuery:nil withOutputAtPath:outputPath];
+        
+        // This will output a file containing all testcases containing a <failure> but NOT with text indicating it was a timeout
         if (self.config.failureXmlOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"FailureReport.xml"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/failure[@message!=\"Timed out waiting for the test to produce output. Test was aborted.\"]" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {} applyXQuery:@"testcase/failure[@message!=\"Timed out waiting for the test to produce output. Test was aborted.\"]" withOutputAtPath:outputPath];
         }
-        
+        // This will output a file containing all testcases containing an <error>
         if (self.config.errorXmlOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"ErrorReport.xml"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/error" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {} applyXQuery:@"testcase/error" withOutputAtPath:outputPath];
         }
+        // This will output a file containing all testcases containing a <failure> AND with text indicating it was a timeout
         if (self.config.timeoutXmlOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TimeoutReport.xml"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/failure[@message=\"Timed out waiting for the test to produce output. Test was aborted.\"]" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {} applyXQuery:@"testcase/failure[@message=\"Timed out waiting for the test to produce output. Test was aborted.\"]" withOutputAtPath:outputPath];
         }
     }
 

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -313,11 +313,24 @@ maxprocs(void)
         if ([fm fileExistsAtPath:outputPath]) {
             [fm removeItemAtPath:outputPath error:nil];
         }
-        [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {
+        [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:nil onReportCollected:^(NSURL *fileUrl) {
 //            NSError *error;
 //            NSFileManager *fm = [NSFileManager new];
 //            [fm removeItemAtURL:fileUrl error:&error];
         } outputAtPath:outputPath];
+        if (self.config.failureXmlOutput) {
+            outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"FailureReport.xml"];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/failure[@message!=\"Timed out waiting for the test to produce output. Test was aborted.\"]" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+        }
+        
+        if (self.config.errorXmlOutput) {
+            outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"ErrorReport.xml"];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/error" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+        }
+        if (self.config.timeoutXmlOutput) {
+            outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TimeoutReport.xml"];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory applyXQuery:@"testcase/failure[@message=\"Timed out waiting for the test to produce output. Test was aborted.\"]" onReportCollected:^(NSURL *fileUrl) {} outputAtPath:outputPath];
+        }
     }
 
     return rc;

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -30,7 +30,7 @@
 - (void)testCollectReportsFromPath {
     NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
     NSString *outputPath = [path stringByAppendingPathComponent:@"result.xml"];
-    [BPReportCollector collectReportsFromPath:path onReportCollected:^(NSURL *fileUrl) {
+    [BPReportCollector collectReportsFromPath:path applyXQuery:nil onReportCollected:^(NSURL *fileUrl) {
         NSError *error;
         NSFileManager *fm = [NSFileManager new];
         [fm removeItemAtURL:fileUrl error:&error];

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -30,12 +30,12 @@
 - (void)testCollectReportsFromPath {
     NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
     NSString *outputPath = [path stringByAppendingPathComponent:@"result.xml"];
-    [BPReportCollector collectReportsFromPath:path applyXQuery:nil onReportCollected:^(NSURL *fileUrl) {
+    [BPReportCollector collectReportsFromPath:path onReportCollected:^(NSURL *fileUrl) {
         NSError *error;
         NSFileManager *fm = [NSFileManager new];
         [fm removeItemAtURL:fileUrl error:&error];
         XCTAssertNil(error);
-    }  outputAtPath:outputPath];
+    } applyXQuery:nil withOutputAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;
     NSXMLDocument *doc = [[NSXMLDocument alloc] initWithData:data options:0 error:&error];

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -30,12 +30,7 @@
 - (void)testCollectReportsFromPath {
     NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
     NSString *outputPath = [path stringByAppendingPathComponent:@"result.xml"];
-    [BPReportCollector collectReportsFromPath:path onReportCollected:^(NSURL *fileUrl) {
-//        NSError *error;
-//        NSFileManager *fm = [NSFileManager new];
-//        [fm removeItemAtURL:fileUrl error:&error];
-//        XCTAssertNil(error);
-    } applyXQuery:nil withOutputAtPath:outputPath];
+    [BPReportCollector collectReportsFromPath:path onReportCollected:nil applyXQuery:nil withOutputAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;
     NSXMLDocument *doc = [[NSXMLDocument alloc] initWithData:data options:0 error:&error];
@@ -70,7 +65,7 @@
     XCTAssertTrue([[[root attributeForName:@"tests"] stringValue] isEqualToString:@"8"], @"test count is wrong");
     XCTAssertTrue([[[root attributeForName:@"errors"] stringValue] isEqualToString:@"1"], @"test count is wrong");
     XCTAssertTrue([[[root attributeForName:@"failures"] stringValue] isEqualToString:@"0"], @"test count is wrong");
-    
+
     NSLog(@"%@, %@, %@", [[root attributeForName:@"tests"] stringValue], [[root attributeForName:@"errors"] stringValue], [[root attributeForName:@"failures"] stringValue]);
     NSFileManager *fm = [NSFileManager new];
     [fm removeItemAtPath:outputPath error:&error];

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -31,10 +31,10 @@
     NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
     NSString *outputPath = [path stringByAppendingPathComponent:@"result.xml"];
     [BPReportCollector collectReportsFromPath:path onReportCollected:^(NSURL *fileUrl) {
-        NSError *error;
-        NSFileManager *fm = [NSFileManager new];
-        [fm removeItemAtURL:fileUrl error:&error];
-        XCTAssertNil(error);
+//        NSError *error;
+//        NSFileManager *fm = [NSFileManager new];
+//        [fm removeItemAtURL:fileUrl error:&error];
+//        XCTAssertNil(error);
     } applyXQuery:nil withOutputAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -51,4 +51,30 @@
     [fm removeItemAtPath:outputPath error:&error];
     XCTAssertNil(error);
 }
+
+- (void)testCollectReportsFromPathWithXQuery {
+    NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
+    NSString *outputPath = [path stringByAppendingPathComponent:@"result.xml"];
+    [BPReportCollector collectReportsFromPath:path onReportCollected:^(NSURL *fileUrl) {
+        NSError *error;
+        NSFileManager *fm = [NSFileManager new];
+        [fm removeItemAtURL:fileUrl error:&error];
+        XCTAssertNil(error);
+    } applyXQuery:@"testcase/error" withOutputAtPath:outputPath];
+    NSData *data = [NSData dataWithContentsOfFile:outputPath];
+    NSError *error;
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithData:data options:0 error:&error];
+    XCTAssertNil(error);
+    NSArray *testsuitesNodes =  [doc nodesForXPath:[NSString stringWithFormat:@".//%@", @"testsuites"] error:&error];
+    NSXMLElement *root = testsuitesNodes[0];
+    XCTAssertTrue([[[root attributeForName:@"tests"] stringValue] isEqualToString:@"8"], @"test count is wrong");
+    XCTAssertTrue([[[root attributeForName:@"errors"] stringValue] isEqualToString:@"1"], @"test count is wrong");
+    XCTAssertTrue([[[root attributeForName:@"failures"] stringValue] isEqualToString:@"0"], @"test count is wrong");
+    
+    NSLog(@"%@, %@, %@", [[root attributeForName:@"tests"] stringValue], [[root attributeForName:@"errors"] stringValue], [[root attributeForName:@"failures"] stringValue]);
+    NSFileManager *fm = [NSFileManager new];
+    [fm removeItemAtPath:outputPath error:&error];
+    XCTAssertNil(error);
+}
+
 @end

--- a/Bluepill-runner/BluepillRunnerTests/simulator/1/result1.xml
+++ b/Bluepill-runner/BluepillRunnerTests/simulator/1/result1.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Selected tests" tests="148" failures="2" errors="1" time="1029.446000">
+    <testsuite tests="31" failures="2" errors="1" time="425.108000" timestamp="2018-12-03T12:43:05GMT-08:00" name="Test.xctest">
+        <testsuite tests="8" failures="0" errors="1" time="12.796000" timestamp="2018-12-03T13:07:05GMT-08:00" name="TestFileA">
+            <testcase classname="TestFileA" name="UnitTest1" time="0.061000">
+                <system-out></system-out>
+                <error type="Error" message="Some Error.">
+                </error>
+            </testcase>
+        </testsuite>
+        <testsuite tests="8" failures="2" errors="0" time="12.796000" timestamp="2018-12-03T13:07:05GMT-08:00" name="TestFileB">
+            <testcase classname="TestFileB" name="UnitTest2" time="0.061000">
+                <system-out></system-out>
+                <failure type="Failure" message="Some Failure.">
+                </failure>
+            </testcase>
+            <testcase classname="TestFileB" name="UnitTest3" time="0.061000">
+                <system-out></system-out>
+                <failure type="Failure" message="Timed out waiting for the test to produce output. Test was aborted.">
+                </failure>
+            </testcase>
+        </testsuite>
+    </testsuite>
 </testsuites>
 

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -84,6 +84,12 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSNumber *launchTimeout;
 @property (nonatomic, strong) NSNumber *deleteTimeout;
 
+@property (nonatomic) BOOL saveRetryXml;
+@property (nonatomic) BOOL failureXmlOutput;
+@property (nonatomic) BOOL errorXmlOutput;
+@property (nonatomic) BOOL timeoutXmlOutput;
+
+
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;
 

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -143,7 +143,16 @@ struct BPOptions {
             "A .GlobalPreferences.plist simulator preferences file to be copied to any newly created simulators before booting"},
     {363, "script-file", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "scriptFilePath",
         "A script that will be called after the simulator is booted, but before tests are run. Can be used to do any setup (e.g. installing certs). The environment will contain $BP_DEVICE_ID with the ID of the simulator and $BP_DEVICE_PATH with its full path. Exit with zero for success and non-zero for failure."},
-
+    
+    // Experimental Options
+    {364, "save-retry-xml", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "saveRetryXml",
+        "When retrying copy the previous XML file to /retries rather than overwrite it."},
+    {365, "failure-xml-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "failureXmlOutput",
+        "Create a separate XML report containing only test failures."},
+    {366, "error-xml-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "errorXmlOutput",
+        "Create a separate XML report containing only test errors."},
+    {367, "timeout-xml-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "timeoutXmlOutput",
+        "Create a separate XML report containing only test timeouts."},
     {0, 0, 0, 0, 0, 0, 0}
 };
 


### PR DESCRIPTION
This adds the ability to preserve the logs from failed attempts mentioned in #238 by creating a subfolder to copy those failed xml files too. Additionally added some experimental features to parse the entirety of these logs and create a separate .xml report containing all failures/errors/timeouts. All of these are enabled via config options.

This doesn't fix the issue of the final report not containing the correct number of passed tests (as they're lost in the retry attempt) so the next step would be to merge the successful tests into the final log, which I'm hoping to work on fixing next.

Feedback appreciated.