### PR TITLE
Trace Event Logging JSON

### DIFF
--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -20,8 +20,16 @@
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
                   outputAtPath:(NSString *)finalReportPath;
 
+/*!
+ * @discussion collect xml reports from the reportsPath(recursive) and output a final TraceEvent report
+ * @param collectReportsFromPath parent path to the reports
+ * @param withTestConfig A dictionay containing any data to attach to the TraceEvent report
+ * @param applyXQuery apply this XQuery string to the
+ * @param hideSuccesses whether the final report should contain successful test events or only failures
+ * @param withTraceEventAtPath the path to save the TraceReport
+ */
 + (void)collectReportsFromPath:(NSString *)reportsPath
-                 withOtherData:(NSDictionary *)otherData
+                withTestConfig:(NSDictionary *)otherData
                    applyXQuery:(NSString *)XQuery
                  hideSuccesses:(BOOL)hideSuccesses
           withTraceEventAtPath:(NSString *)finalReportPath;

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -9,25 +9,6 @@
 
 #import <Foundation/Foundation.h>
 
-@interface TraceEvent  : NSObject
-@property (strong, nonatomic) NSMutableArray *traceEvents;
-@property (strong, nonatomic) NSString *displayTimeUnit;
-@property (strong, nonatomic) NSString *systemTraceEvents;
-@property (strong, nonatomic) NSDictionary *otherData;
-@property (strong, nonatomic) NSDictionary *stackFrames;
-@property (strong, nonatomic) NSArray *samples;
-- (id) init;
-- (instancetype)initWithData:(NSDictionary *)data;
-- (void)appendCompleteTraceEvent:(NSString *)name
-                                        :(NSString *)cat
-                                        :(NSInteger)ts
-                                        :(float)dur
-                                        :(NSInteger)pid
-                                        :(NSInteger)tid
-                                        :(NSDictionary *)args;
-- (NSDictionary *)toDict;
-@end
-
 @interface BPReportCollector : NSObject
 
 /*!

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -21,17 +21,17 @@
                   outputAtPath:(NSString *)finalReportPath;
 
 /*!
- * @discussion collect xml reports from the reportsPath(recursive) and output a final TraceEvent report
+ * @discussion collect xml reports from the reportsPath(recursive) and output a final json TraceEvent report
  * @param reportsPath parent path to the reports
- * @param testConfig A dictionay containing any data to attach to the TraceEvent report
+ * @param testConfig A dictionay containing test configuration data to attach to the TraceEvent report
  * @param XQuery apply this XQuery string to the
- * @param hideSuccesses whether the final report should contain successful test events or only failures
+ * @param excludePassedTests whether the final report should contain successful test events or only failures
  * @param finalReportPath the path to save the TraceReport
  */
 + (void)collectReportsFromPath:(NSString *)reportsPath
                 withTestConfig:(NSDictionary *)testConfig
                    applyXQuery:(NSString *)XQuery
-                 hideSuccesses:(BOOL)hideSuccesses
+            excludePassedTests:(BOOL)excludePassedTests
           withTraceEventAtPath:(NSString *)finalReportPath;
 @end
 

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -9,6 +9,25 @@
 
 #import <Foundation/Foundation.h>
 
+@interface TraceEvent  : NSObject
+@property (strong, nonatomic) NSMutableArray *traceEvents;
+@property (strong, nonatomic) NSString *displayTimeUnit;
+@property (strong, nonatomic) NSString *systemTraceEvents;
+@property (strong, nonatomic) NSDictionary *otherData;
+@property (strong, nonatomic) NSDictionary *stackFrames;
+@property (strong, nonatomic) NSArray *samples;
+- (id) init;
+- (instancetype)initWithData:(NSDictionary *)data;
+- (void)appendCompleteTraceEvent:(NSString *)name
+                                        :(NSString *)cat
+                                        :(NSInteger)ts
+                                        :(float)dur
+                                        :(NSInteger)pid
+                                        :(NSInteger)tid
+                                        :(NSDictionary *)args;
+- (NSDictionary *)toDict;
+@end
+
 @interface BPReportCollector : NSObject
 
 /*!
@@ -20,4 +39,10 @@
              onReportCollected:(void (^)(NSURL *fileUrl))fileHandler
                   outputAtPath:(NSString *)finalReportPath;
 
++ (void)collectReportsFromPath:(NSString *)reportsPath
+                 withOtherData:(NSDictionary *)otherData
+                   applyXQuery:(NSString *)XQuery
+                 hideSuccesses:(BOOL)hideSuccesses
+          withTraceEventAtPath:(NSString *)finalReportPath;
 @end
+

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -22,11 +22,11 @@
 
 /*!
  * @discussion collect xml reports from the reportsPath(recursive) and output a final TraceEvent report
- * @param collectReportsFromPath parent path to the reports
- * @param withTestConfig A dictionay containing any data to attach to the TraceEvent report
- * @param applyXQuery apply this XQuery string to the
+ * @param reportsPath parent path to the reports
+ * @param otherData A dictionay containing any data to attach to the TraceEvent report
+ * @param XQuery apply this XQuery string to the
  * @param hideSuccesses whether the final report should contain successful test events or only failures
- * @param withTraceEventAtPath the path to save the TraceReport
+ * @param finalReportPath the path to save the TraceReport
  */
 + (void)collectReportsFromPath:(NSString *)reportsPath
                 withTestConfig:(NSDictionary *)otherData

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.h
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.h
@@ -23,13 +23,13 @@
 /*!
  * @discussion collect xml reports from the reportsPath(recursive) and output a final TraceEvent report
  * @param reportsPath parent path to the reports
- * @param otherData A dictionay containing any data to attach to the TraceEvent report
+ * @param testConfig A dictionay containing any data to attach to the TraceEvent report
  * @param XQuery apply this XQuery string to the
  * @param hideSuccesses whether the final report should contain successful test events or only failures
  * @param finalReportPath the path to save the TraceReport
  */
 + (void)collectReportsFromPath:(NSString *)reportsPath
-                withTestConfig:(NSDictionary *)otherData
+                withTestConfig:(NSDictionary *)testConfig
                    applyXQuery:(NSString *)XQuery
                  hideSuccesses:(BOOL)hideSuccesses
           withTraceEventAtPath:(NSString *)finalReportPath;

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -162,7 +162,7 @@
                                               currentSim, @"simNum",
                                               nil];
 
-                        [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] category:className timestamp:timestamp duration:duration processId:0 threadID:0 args:args]
+                        [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] category:className timestamp:timestamp duration:duration processId:0 threadID:0 args:args];
                         currentTime = [currentTime dateByAddingTimeInterval:duration/1000];
                     }
                 }

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -105,9 +105,9 @@
                                              fprintf(stderr, "Failed to process url %s", [[url absoluteString] UTF8String]);
                                              return YES;
                                          }];
-    TraceEvent *traceEvent = [[TraceEvent alloc] initWithData:testConfig];
+    BPTraceEvent *traceEvent = [[BPTraceEvent alloc] initWithData:testConfig];
     NSCharacterSet* notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
-    NSString *currentSim = @"-1";
+    NSString *currentSim = @"";
 
     for (NSURL *url in enumerator) {
         NSError *error;

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -162,7 +162,7 @@
                                               currentSim, @"simNum",
                                               nil];
 
-                        [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] :className :timestamp :duration :0 :0 :args];
+                        [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] category:className timestamp:timestamp duration:duration processId:0 threadID:0 args:args]
                         currentTime = [currentTime dateByAddingTimeInterval:duration/1000];
                     }
                 }

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -89,7 +89,7 @@
 }
 
 + (void)collectReportsFromPath:(NSString *)reportsPath
-                 withOtherData:(NSDictionary *)otherData
+                 withTestConfig:(NSDictionary *)testConfig
                    applyXQuery:(NSString *)XQuery
                  hideSuccesses:(BOOL)hideSuccesses
           withTraceEventAtPath:(NSString *)finalReportPath {
@@ -105,7 +105,7 @@
                                              fprintf(stderr, "Failed to process url %s", [[url absoluteString] UTF8String]);
                                              return YES;
                                          }];
-    TraceEvent *traceEvent = [[TraceEvent alloc] initWithData:otherData];
+    TraceEvent *traceEvent = [[TraceEvent alloc] initWithData:testConfig];
     NSCharacterSet* notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
     NSString *currentSim = @"-1";
 

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -87,4 +87,138 @@
     [xmlData writeToFile:finalReportPath atomically:YES];
 }
 
++ (void)collectReportsFromPath:(NSString *)reportsPath
+                                            withOtherData:(NSDictionary *)otherData
+                                              applyXQuery:(NSString *)XQuery
+                                            hideSuccesses:(BOOL)hideSuccesses
+                                     withTraceEventAtPath:(NSString *)finalReportPath {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    NSURL *directoryURL = [NSURL fileURLWithPath:reportsPath isDirectory:YES];
+    NSArray *keys = [NSArray arrayWithObject:NSURLIsDirectoryKey];
+    NSDirectoryEnumerator *enumerator = [fileManager
+                                         enumeratorAtURL:directoryURL
+                                         includingPropertiesForKeys:keys
+                                         options:0
+                                         errorHandler:^(NSURL *url, NSError *error) {
+                                             fprintf(stderr, "Failed to process url %s", [[url absoluteString] UTF8String]);
+                                             return YES;
+                                         }];
+    TraceEvent *traceEvent = [[TraceEvent alloc] initWithData:otherData];
+    NSCharacterSet* notDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+    NSString *currentSim = @"-1";
+
+    for (NSURL *url in enumerator) {
+        NSError *error;
+        NSNumber *isDirectory = nil;
+        NSString *currentFolder = nil;
+        if (![url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
+            fprintf(stderr, "Failed to get resource from url %s", [[url absoluteString] UTF8String]);
+        }
+        // Getting which sim # folder we're currently in so we can attach that to all the tests in that folder
+        else if ([isDirectory boolValue]) {
+            currentFolder = [url pathComponents][[[url pathComponents] count] - 1 ];
+            if ([currentFolder rangeOfCharacterFromSet:notDigits].location == NSNotFound) {
+                currentSim = currentFolder;
+            }
+        }
+        else if (![isDirectory boolValue]) {
+            if ([[url pathExtension] isEqualToString:@"xml"]) {
+                NSError *error;
+                NSXMLDocument *doc = [[NSXMLDocument alloc] initWithContentsOfURL:url options:0 error:&error];
+                if (error) {
+                    [BPUtils printInfo:ERROR withString:@"Failed to parse %@: %@", url, error.localizedDescription];
+                    // When app crash before test start, it can result in empty xml file
+                    // Test results from other BP workers should continue to parse
+                    continue;
+                }
+
+                NSArray *testsuitesNodes = [doc objectsForXQuery:XQuery error:&error];
+                NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+                [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
+                NSDate *currentTime = nil;
+
+                for (NSXMLElement *testsuite in testsuitesNodes) {
+                    currentTime = [dateFormatter dateFromString:[[testsuite attributeForName:@"timestamp"] stringValue]];
+                    for (NSXMLElement *testcaseChild in [testsuite children]) {
+
+                        // Tests with errors or failures will have more than 1 child node
+                        if (hideSuccesses && [testcaseChild childCount] == 1) {
+                            continue;
+                        }
+
+                        NSString *testName = [[testcaseChild attributeForName:@"name"] stringValue];
+                        NSString *className = [[testcaseChild attributeForName:@"classname"] stringValue];
+                        NSInteger timestamp = [[NSString stringWithFormat:@"%f", [currentTime timeIntervalSince1970] * 1000] integerValue];
+                        float duration = [[[testcaseChild attributeForName:@"time"] stringValue] floatValue];
+                        NSDictionary *args = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                              currentSim, @"simNum",
+                                              nil];
+
+                        [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] :className :timestamp :duration :0 :0 :args];
+                        currentTime = [currentTime dateByAddingTimeInterval:duration];
+                    }
+                }
+            }
+        }
+    }
+    NSError *error;
+    NSDictionary *traceEventDict = [traceEvent toDict];
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:traceEventDict options:0 error:&error];
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    [jsonString writeToFile:finalReportPath atomically:YES encoding:NSUTF8StringEncoding error:&error];
+
+}
+
+@end
+
+@implementation TraceEvent
+- (instancetype)init {
+    self = [self initWithData:nil];
+    return self;
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        _displayTimeUnit = @"ns";
+        _systemTraceEvents = @"SystemTraceData";
+        _otherData = data;
+        _stackFrames = [[NSDictionary alloc] init];
+        _samples = [NSMutableArray array];
+        _traceEvents = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)appendCompleteTraceEvent:(NSString *)name
+                                        :(NSString *)cat
+                                        :(NSInteger)ts
+                                        :(float)dur
+                                        :(NSInteger)pid
+                                        :(NSInteger)tid
+                                        :(NSDictionary *)args {
+    NSDictionary *newTraceEvent = [[NSDictionary alloc] initWithObjectsAndKeys:
+     name, @"name",
+     cat, @"cat",
+     @"X", @"ph", // Complete event type (with both a timestamp and duration)
+     [NSString stringWithFormat: @"%ld", (long)ts], @"ts",
+     [[NSNumber numberWithFloat:dur] stringValue], @"dur",
+     [NSString stringWithFormat: @"%ld", (long)pid], @"pid",
+     [NSString stringWithFormat: @"%ld", (long)tid], @"tid",
+     args, @"args",
+     nil];
+
+    [_traceEvents addObject:newTraceEvent];
+}
+- (NSDictionary *)toDict {
+    return [[NSDictionary alloc] initWithObjectsAndKeys:
+            _displayTimeUnit, @"displayTimeUnit",
+            _systemTraceEvents, @"systemTraceEvents",
+            _otherData, @"otherData",
+            _stackFrames, @"stackFrames",
+            _samples, @"samples",
+            _traceEvents, @"traceEvents",
+            nil];
+}
 @end

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -157,13 +157,13 @@
                         NSString *testName = [[testcaseChild attributeForName:@"name"] stringValue];
                         NSString *className = [[testcaseChild attributeForName:@"classname"] stringValue];
                         NSInteger timestamp = [[NSString stringWithFormat:@"%f", [currentTime timeIntervalSince1970] * 1000] integerValue];
-                        float duration = [[[testcaseChild attributeForName:@"time"] stringValue] floatValue];
+                        int duration = [[[testcaseChild attributeForName:@"time"] stringValue] floatValue] * 1000;
                         NSDictionary *args = [[NSDictionary alloc] initWithObjectsAndKeys:
                                               currentSim, @"simNum",
                                               nil];
 
                         [traceEvent appendCompleteTraceEvent:[NSString stringWithFormat:@"%@/%@", className, testName] :className :timestamp :duration :0 :0 :args];
-                        currentTime = [currentTime dateByAddingTimeInterval:duration];
+                        currentTime = [currentTime dateByAddingTimeInterval:duration/1000];
                     }
                 }
             }

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -117,7 +117,15 @@
             fprintf(stderr, "Failed to get resource from url %s", [[url absoluteString] UTF8String]);
         } else if ([isDirectory boolValue]) {
             // Getting which sim # folder we're currently in so we can attach that to all the tests in that folder
+            // Because the sim outputs all go in a folder like "1", "2", etc. as we walk through the
+            // Subfolders in out output path, we'll either see a folder named "1" or a subfolder of it
+            // named "failures", when we see a number we know to update the current sim number, and if
+            // the directory isn't a number then we're in the failure folder
+
+            // We get the folder name as the last path component of the current path
             currentFolder = [url pathComponents][[[url pathComponents] count] - 1];
+
+            // When the current folder's name contains only digits, we've reached the next sim and update
             if ([currentFolder rangeOfCharacterFromSet:notDigits].location == NSNotFound) {
                 currentSim = currentFolder;
             }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -307,6 +307,17 @@ maxprocs(void)
     if (app) {
         [app terminate];
     }
+    
+    NSDictionary *otherData = [[NSDictionary alloc] initWithObjectsAndKeys:
+                               [[self.config.testBundlePath componentsSeparatedByString:@"/"] lastObject], @"Test Bundle",
+                               self.config.deviceType, @"Device Type",
+                               self.config.runtime, @"iOS Version",
+                               @XCODE_VERSION, @"XCode Version",
+                               @BP_VERSION, @"BluePill Version",
+                               [NSHost currentHost], @"Host Name",
+                               [[NSProcessInfo processInfo] operatingSystemVersionString], @"OS Version",
+                               nil];
+
     if (self.config.outputDirectory) {
         NSString *outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TEST-FinalReport.xml"];
         NSFileManager *fm = [NSFileManager new];
@@ -314,10 +325,16 @@ maxprocs(void)
             [fm removeItemAtPath:outputPath error:nil];
         }
         [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {
-//            NSError *error;
-//            NSFileManager *fm = [NSFileManager new];
-//            [fm removeItemAtURL:fileUrl error:&error];
+            //            NSError *error;
+            //            NSFileManager *fm = [NSFileManager new];
+            //            [fm removeItemAtURL:fileUrl error:&error];
         } outputAtPath:outputPath];
+
+        if (self.config.traceEventOutput) {
+            outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TraceReport.json"];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withOtherData:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventHideSuccesses withTraceEventAtPath:outputPath];
+        }
+
     }
 
     return rc;

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -328,7 +328,7 @@ maxprocs(void)
 
         if (self.config.traceEventOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TraceReport.json"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withOtherData:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withTestConfig:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
         }
 
     }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -324,15 +324,11 @@ maxprocs(void)
         if ([fm fileExistsAtPath:outputPath]) {
             [fm removeItemAtPath:outputPath error:nil];
         }
-        [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:^(NSURL *fileUrl) {
-            //            NSError *error;
-            //            NSFileManager *fm = [NSFileManager new];
-            //            [fm removeItemAtURL:fileUrl error:&error];
-        } outputAtPath:outputPath];
+        [BPReportCollector collectReportsFromPath:self.config.outputDirectory onReportCollected:nil outputAtPath:outputPath];
 
         if (self.config.traceEventOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TraceReport.json"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withOtherData:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventHideSuccesses withTraceEventAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withOtherData:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
         }
 
     }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -308,7 +308,7 @@ maxprocs(void)
         [app terminate];
     }
     
-    NSDictionary *otherData = [[NSDictionary alloc] initWithObjectsAndKeys:
+    NSDictionary *testConfig = [[NSDictionary alloc] initWithObjectsAndKeys:
                                [[self.config.testBundlePath componentsSeparatedByString:@"/"] lastObject], @"Test Bundle",
                                self.config.deviceType, @"Device Type",
                                self.config.runtime, @"iOS Version",
@@ -328,7 +328,7 @@ maxprocs(void)
 
         if (self.config.traceEventOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TraceReport.json"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withTestConfig:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
         }
 
     }

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -328,7 +328,7 @@ maxprocs(void)
 
         if (self.config.traceEventOutput) {
             outputPath = [self.config.outputDirectory stringByAppendingPathComponent:@"TraceReport.json"];
-            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
+            [BPReportCollector collectReportsFromPath:self.config.outputDirectory withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" excludePassedTests:self.config.traceEventErrorOnly withTraceEventAtPath:outputPath];
         }
 
     }

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
@@ -35,7 +35,7 @@
 - (void)appendCompleteTraceEvent:(NSString *)name
                                 :(NSString *)category
                                 :(NSInteger)timestamp
-                                :(float)duration
+                                :(NSInteger)duration
                                 :(NSInteger)process_id
                                 :(NSInteger)thread_id
                                 :(NSDictionary *)args;

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
@@ -12,7 +12,7 @@
  Trace Event Format Definition: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
  */
 
-@interface TraceEvent : NSObject
+@interface BPTraceEvent : NSObject
 @property (strong, nonatomic) NSMutableArray *traceEvents;
 @property (strong, nonatomic) NSString *displayTimeUnit;
 @property (strong, nonatomic) NSString *systemTraceEvents;
@@ -28,17 +28,17 @@
  * @param category Type of the event, for complete events this will be 'X', indicating the event will contain a duration and implicitly it is an event that has both a beginning and an end (See Trace Event Definition document for more)
  * @param timestamp Unix timestamp indicating when the event started
  * @param duration Length of a complete event
- * @param process_id ID of the process the event occured on
- * @param thread_id ID of the thread the event ocurred on
+ * @param processId ID of the process the event occured on
+ * @param threadId ID of the thread the event ocurred on
  * @param args Additional key value pairs to attach to the event
  */
 - (void)appendCompleteTraceEvent:(NSString *)name
-                                :(NSString *)category
-                                :(NSInteger)timestamp
-                                :(NSInteger)duration
-                                :(NSInteger)process_id
-                                :(NSInteger)thread_id
-                                :(NSDictionary *)args;
+                        category:(NSString *)category
+                       timestamp:(NSInteger)timestamp
+                        duration:(NSInteger)duration
+                       processId:(NSInteger)processId
+                        threadID:(NSInteger)threadId
+                            args:(NSDictionary *)args;
 
 - (NSDictionary *)toDict;
 @end

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
@@ -39,6 +39,8 @@
                        processId:(NSInteger)processId
                         threadID:(NSInteger)threadId
                             args:(NSDictionary *)args;
-
-- (NSDictionary *)toDict;
+/*!
+ * @discussion Outputs a dictionary representation of a TraceEvent for serialization
+*/
+- (NSDictionary *)toDictionary;
 @end

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
@@ -12,14 +12,16 @@
  Trace Event Format Definition: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
  */
 
-@interface TraceEvent  : NSObject
+@interface TraceEvent : NSObject
 @property (strong, nonatomic) NSMutableArray *traceEvents;
 @property (strong, nonatomic) NSString *displayTimeUnit;
 @property (strong, nonatomic) NSString *systemTraceEvents;
 @property (strong, nonatomic) NSDictionary *otherData;
 @property (strong, nonatomic) NSDictionary *stackFrames;
 @property (strong, nonatomic) NSArray *samples;
+
 - (instancetype)initWithData:(NSDictionary *)data;
+
 /*!
  * @discussion Appends a full TraceEvent to the list of events
  * @param name Name of the event
@@ -37,5 +39,6 @@
                                 :(NSInteger)process_id
                                 :(NSInteger)thread_id
                                 :(NSDictionary *)args;
+
 - (NSDictionary *)toDict;
 @end

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.h
@@ -1,0 +1,41 @@
+//
+//  BPTraceEvent.h
+//  Bluepill
+//
+//  Created by Eric Snyder on 12/17/18.
+//  Copyright © 2018 LinkedIn. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/*
+ Trace Event Format Definition: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+ */
+
+@interface TraceEvent  : NSObject
+@property (strong, nonatomic) NSMutableArray *traceEvents;
+@property (strong, nonatomic) NSString *displayTimeUnit;
+@property (strong, nonatomic) NSString *systemTraceEvents;
+@property (strong, nonatomic) NSDictionary *otherData;
+@property (strong, nonatomic) NSDictionary *stackFrames;
+@property (strong, nonatomic) NSArray *samples;
+- (instancetype)initWithData:(NSDictionary *)data;
+/*!
+ * @discussion Appends a full TraceEvent to the list of events
+ * @param name Name of the event
+ * @param category Type of the event, for complete events this will be 'X', indicating the event will contain a duration and implicitly it is an event that has both a beginning and an end (See Trace Event Definition document for more)
+ * @param timestamp Unix timestamp indicating when the event started
+ * @param duration Length of a complete event
+ * @param process_id ID of the process the event occured on
+ * @param thread_id ID of the thread the event ocurred on
+ * @param args Additional key value pairs to attach to the event
+ */
+- (void)appendCompleteTraceEvent:(NSString *)name
+                                :(NSString *)category
+                                :(NSInteger)timestamp
+                                :(float)duration
+                                :(NSInteger)process_id
+                                :(NSInteger)thread_id
+                                :(NSDictionary *)args;
+- (NSDictionary *)toDict;
+@end

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
@@ -30,7 +30,7 @@
 - (void)appendCompleteTraceEvent:(NSString *)name
                                 :(NSString *)category
                                 :(NSInteger)timestamp
-                                :(float)duration
+                                :(NSInteger)duration
                                 :(NSInteger)process_id
                                 :(NSInteger)thread_id
                                 :(NSDictionary *)args {

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
@@ -17,7 +17,7 @@
 - (instancetype)initWithData:(NSDictionary *)data {
     self = [super init];
     if (self) {
-        _displayTimeUnit = @"ns";
+        _displayTimeUnit = @"ms";
         _systemTraceEvents = @"SystemTraceData";
         _otherData = data;
         _stackFrames = [[NSDictionary alloc] init];

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
@@ -8,7 +8,7 @@
 
 #import "BPTraceEvent.h"
 
-@implementation TraceEvent
+@implementation BPTraceEvent
 - (instancetype)init {
     self = [self initWithData:nil];
     return self;
@@ -28,20 +28,20 @@
 }
 
 - (void)appendCompleteTraceEvent:(NSString *)name
-                                :(NSString *)category
-                                :(NSInteger)timestamp
-                                :(NSInteger)duration
-                                :(NSInteger)process_id
-                                :(NSInteger)thread_id
-                                :(NSDictionary *)args {
+                        category:(NSString *)category
+                       timestamp:(NSInteger)timestamp
+                        duration:(NSInteger)duration
+                       processId:(NSInteger)processId
+                        threadID:(NSInteger)threadId
+                            args:(NSDictionary *)args {
     NSDictionary *newTraceEvent = [[NSDictionary alloc] initWithObjectsAndKeys:
                                    name, @"name",
                                    category, @"cat",
                                    @"X", @"ph", // Complete event type (with both a timestamp and duration)
                                    [NSString stringWithFormat: @"%ld", (long)timestamp], @"ts",
                                    [[NSNumber numberWithFloat:duration] stringValue], @"dur",
-                                   [NSString stringWithFormat: @"%ld", (long)process_id], @"pid",
-                                   [NSString stringWithFormat: @"%ld", (long)thread_id], @"tid",
+                                   [NSString stringWithFormat: @"%ld", (long)processId], @"pid",
+                                   [NSString stringWithFormat: @"%ld", (long)threadId], @"tid",
                                    args, @"args",
                                    nil];
 

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
@@ -47,7 +47,7 @@
 
     [_traceEvents addObject:newTraceEvent];
 }
-- (NSDictionary *)toDict {
+- (NSDictionary *)toDictionary {
     return [[NSDictionary alloc] initWithObjectsAndKeys:
             _displayTimeUnit, @"displayTimeUnit",
             _systemTraceEvents, @"systemTraceEvents",

--- a/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
+++ b/Bluepill-runner/Bluepill-runner/BPTraceEvent.m
@@ -1,0 +1,60 @@
+//
+//  BPTraceEvent.m
+//  bluepill
+//
+//  Created by Eric Snyder on 12/17/18.
+//  Copyright © 2018 LinkedIn. All rights reserved.
+//
+
+#import "BPTraceEvent.h"
+
+@implementation TraceEvent
+- (instancetype)init {
+    self = [self initWithData:nil];
+    return self;
+}
+
+- (instancetype)initWithData:(NSDictionary *)data {
+    self = [super init];
+    if (self) {
+        _displayTimeUnit = @"ns";
+        _systemTraceEvents = @"SystemTraceData";
+        _otherData = data;
+        _stackFrames = [[NSDictionary alloc] init];
+        _samples = [NSMutableArray array];
+        _traceEvents = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)appendCompleteTraceEvent:(NSString *)name
+                                :(NSString *)category
+                                :(NSInteger)timestamp
+                                :(float)duration
+                                :(NSInteger)process_id
+                                :(NSInteger)thread_id
+                                :(NSDictionary *)args {
+    NSDictionary *newTraceEvent = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                   name, @"name",
+                                   category, @"cat",
+                                   @"X", @"ph", // Complete event type (with both a timestamp and duration)
+                                   [NSString stringWithFormat: @"%ld", (long)timestamp], @"ts",
+                                   [[NSNumber numberWithFloat:duration] stringValue], @"dur",
+                                   [NSString stringWithFormat: @"%ld", (long)process_id], @"pid",
+                                   [NSString stringWithFormat: @"%ld", (long)thread_id], @"tid",
+                                   args, @"args",
+                                   nil];
+
+    [_traceEvents addObject:newTraceEvent];
+}
+- (NSDictionary *)toDict {
+    return [[NSDictionary alloc] initWithObjectsAndKeys:
+            _displayTimeUnit, @"displayTimeUnit",
+            _systemTraceEvents, @"systemTraceEvents",
+            _otherData, @"otherData",
+            _stackFrames, @"stackFrames",
+            _samples, @"samples",
+            _traceEvents, @"traceEvents",
+            nil];
+}
+@end

--- a/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
+++ b/Bluepill-runner/Bluepill.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		C467E54C1DC94BB200BC80EE /* BPCLITests.m in Sources */ = {isa = PBXBuildFile; fileRef = C467E54B1DC94BB200BC80EE /* BPCLITests.m */; };
 		C4C614A421814C5C008A2C39 /* BPTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C614A321814C5C008A2C39 /* BPTestHelper.m */; };
 		C4FD8C581DB6E09B000ED28C /* BPPacker.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FD8C571DB6E09B000ED28C /* BPPacker.m */; };
+		E603C53921C8CF1F001EC0E4 /* BPTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E603C53821C8CF1F001EC0E4 /* BPTraceEvent.m */; };
+		E603C53A21C8CF2E001EC0E4 /* BPTraceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E603C53821C8CF1F001EC0E4 /* BPTraceEvent.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +65,8 @@
 		C4C614A321814C5C008A2C39 /* BPTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BPTestHelper.m; path = "../../Bluepill-cli/BPInstanceTests/BPTestHelper.m"; sourceTree = "<group>"; };
 		C4FD8C561DB6E09B000ED28C /* BPPacker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPPacker.h; sourceTree = "<group>"; };
 		C4FD8C571DB6E09B000ED28C /* BPPacker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPPacker.m; sourceTree = "<group>"; };
+		E603C53821C8CF1F001EC0E4 /* BPTraceEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPTraceEvent.m; sourceTree = "<group>"; };
+		E603C53B21C8CF48001EC0E4 /* BPTraceEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPTraceEvent.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +193,8 @@
 				C41C41F21DB04032001F32A2 /* BPApp.m */,
 				BAD848481DBC6A83007034CF /* BPReportCollector.h */,
 				BAD848491DBC6A83007034CF /* BPReportCollector.m */,
+				E603C53821C8CF1F001EC0E4 /* BPTraceEvent.m */,
+				E603C53B21C8CF48001EC0E4 /* BPTraceEvent.h */,
 			);
 			name = Bluepill;
 			path = "Bluepill-runner";
@@ -308,6 +314,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E603C53A21C8CF2E001EC0E4 /* BPTraceEvent.m in Sources */,
 				BA1809E91DBA8FC300D7D130 /* BPRunnerTests.m in Sources */,
 				BA1809FB1DBA949600D7D130 /* BPPacker.m in Sources */,
 				BA1809EB1DBA910400D7D130 /* BPAppTests.m in Sources */,
@@ -326,6 +333,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E603C53921C8CF1F001EC0E4 /* BPTraceEvent.m in Sources */,
 				C4FD8C581DB6E09B000ED28C /* BPPacker.m in Sources */,
 				BAEF4B381DAC539400E68294 /* main.m in Sources */,
 				C41C41F91DB14B5F001F32A2 /* BPRunner.m in Sources */,

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -59,14 +59,14 @@
                                @"BP_VERSION", @"BluePill Version",
                                nil];
 
-    [BPReportCollector collectReportsFromPath:path withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:YES withTraceEventAtPath:outputPath];
+    [BPReportCollector collectReportsFromPath:path withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" excludePassedTests:YES withTraceEventAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;
     NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
 
     XCTAssertEqual([[result allKeys] count], 6);
     XCTAssertEqual([result[@"traceEvents"] count], 3);
-    XCTAssertEqualObjects([result[@"traceEvents"] firstObject][@"dur"], @"0.061");
+    XCTAssertEqualObjects([result[@"traceEvents"] firstObject][@"dur"], @"61");
     XCTAssertEqualObjects([result[@"traceEvents"] firstObject][@"ts"], @"1543871225000");
     XCTAssertEqualObjects([result[@"traceEvents"] firstObject][@"name"], @"TestFileA/UnitTest1");
 

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -50,7 +50,7 @@
 - (void)testCollectReportsFromPathAndCreateTraceEvent {
     NSString *path = [[NSBundle bundleForClass:[self class]] resourcePath];
     NSString *outputPath = [path stringByAppendingPathComponent:@"result.json"];
-    NSDictionary *otherData = [[NSDictionary alloc] initWithObjectsAndKeys:
+    NSDictionary *testConfig = [[NSDictionary alloc] initWithObjectsAndKeys:
                                @"Voyager-iOS", @"Product Name",
                                @"VoyagerTests", @"Batch Number",
                                @"iPhone 6S", @"Device Type",
@@ -59,7 +59,7 @@
                                @"BP_VERSION", @"BluePill Version",
                                nil];
 
-    [BPReportCollector collectReportsFromPath:path withTestConfig:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:YES withTraceEventAtPath:outputPath];
+    [BPReportCollector collectReportsFromPath:path withTestConfig:testConfig applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:YES withTraceEventAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;
     NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];

--- a/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPReportCollectorTests.m
@@ -59,7 +59,7 @@
                                @"BP_VERSION", @"BluePill Version",
                                nil];
 
-    [BPReportCollector collectReportsFromPath:path withOtherData:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:YES withTraceEventAtPath:outputPath];
+    [BPReportCollector collectReportsFromPath:path withTestConfig:otherData applyXQuery:@".//testsuites/testsuite/testsuite" hideSuccesses:YES withTraceEventAtPath:outputPath];
     NSData *data = [NSData dataWithContentsOfFile:outputPath];
     NSError *error;
     NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];

--- a/Bluepill-runner/BluepillRunnerTests/simulator/1/result1.xml
+++ b/Bluepill-runner/BluepillRunnerTests/simulator/1/result1.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="Selected tests" tests="148" failures="2" errors="1" time="1029.446000">
+    <testsuite tests="31" failures="2" errors="1" time="425.108000" timestamp="2018-12-03T12:43:05GMT-08:00" name="Test.xctest">
+        <testsuite tests="8" failures="0" errors="1" time="12.796000" timestamp="2018-12-03T13:07:05GMT-08:00" name="TestFileA">
+            <testcase classname="TestFileA" name="UnitTest1" time="0.061000">
+                <system-out></system-out>
+                <error type="Error" message="Some Error.">
+                </error>
+            </testcase>
+        </testsuite>
+        <testsuite tests="8" failures="2" errors="0" time="12.796000" timestamp="2018-12-03T13:07:05GMT-08:00" name="TestFileB">
+            <testcase classname="TestFileB" name="UnitTest2" time="0.061000">
+                <system-out></system-out>
+                <failure type="Failure" message="Some Failure.">
+                </failure>
+            </testcase>
+            <testcase classname="TestFileB" name="UnitTest3" time="0.061000">
+                <system-out></system-out>
+                <failure type="Failure" message="Timed out waiting for the test to produce output. Test was aborted.">
+                </failure>
+            </testcase>
+        </testsuite>
+    </testsuite>
 </testsuites>
-

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -83,6 +83,9 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSNumber *launchTimeout;
 @property (nonatomic, strong) NSNumber *deleteTimeout;
 
+@property (nonatomic) BOOL traceEventOutput;
+@property (nonatomic) BOOL traceEventHideSuccesses;
+
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;
 

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSNumber *deleteTimeout;
 
 @property (nonatomic) BOOL traceEventOutput;
-@property (nonatomic) BOOL traceEventHideSuccesses;
+@property (nonatomic) BOOL traceEventErrorOnly;
 
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -143,7 +143,7 @@ struct BPOptions {
         "A script that will be called after the simulator is booted, but before tests are run. Can be used to do any setup (e.g. installing certs). The environment will contain $BP_DEVICE_ID with the ID of the simulator and $BP_DEVICE_PATH with its full path. Exit with zero for success and non-zero for failure."},
     {368, "trace-event-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "traceEventOutput",
         "Create a TraceEvent JSON report."},
-    {369, "trace-event-hide-successes", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "traceEventHideSuccesses",
+    {369, "trace-event-error-only", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "traceEventErrorOnly",
         "Remove successful events from the TraceEvent output."},
 
     {0, 0, 0, 0, 0, 0, 0}

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -141,6 +141,10 @@ struct BPOptions {
             "A .GlobalPreferences.plist simulator preferences file to be copied to any newly created simulators before booting"},
     {363, "script-file", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "scriptFilePath",
         "A script that will be called after the simulator is booted, but before tests are run. Can be used to do any setup (e.g. installing certs). The environment will contain $BP_DEVICE_ID with the ID of the simulator and $BP_DEVICE_PATH with its full path. Exit with zero for success and non-zero for failure."},
+    {368, "trace-event-output", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "traceEventOutput",
+        "Create a TraceEvent JSON report."},
+    {369, "trace-event-hide-successes", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "traceEventHideSuccesses",
+        "Remove successful events from the TraceEvent output."},
 
     {0, 0, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
Since there was some interest in adding some kind of TraceEvent log to BP and we also needed a JSON log containing some information about the environment for our logging I went ahead and formatted it to the TraceEvent spec. Right now it builds up the events from the xml reports but ideally I think in the future writing out events as they happen per simulator and just merging all the events into one JSON at the end would be ideal.

I also added a secondary config option to skip over successful tests and only write failed test case events, this probably isn't the ideal way to run it but was a requirement for us to keep the file size down.