### PR TITLE
add BPExitStatusAppTerminatedBeforeTestStarted exit status

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -92,7 +92,7 @@
     self.config.testing_CrashAppOnLaunch = YES;
     self.config.stuckTimeout = @3;
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
-    XCTAssert(exitCode == BPExitStatusAppCrashed, @"Expected: %ld Got: %ld", (long)BPExitStatusAppCrashed, (long)exitCode);
+    XCTAssert(exitCode == BPExitStatusAppTerminatedBeforeTestStarted, @"Expected: %ld Got: %ld", (long)BPExitStatusAppTerminatedBeforeTestStarted, (long)exitCode);
 }
 
 - (void)testAppThatHangsOnLaunch {

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -681,6 +681,9 @@ void onInterrupt(int ignore) {
             context.finalExitStatus = BPExitStatusAppCrashed;
             NEXT([self proceed]);
             return;
+        case BPExitStatusAppTerminatedBeforeTestStarted:
+            NEXT([self proceed]);
+            return;
         case BPExitStatusSimulatorDeleted:
         case BPExitStatusSimulatorReuseFailed:
             self.finalExitStatus = context.exitStatus;

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.h
@@ -22,6 +22,7 @@ typedef NS_ENUM(NSInteger, BPExitStatus) {
     BPExitStatusSimulatorDeleted = 9,
     BPExitStatusUninstallAppFailed = 10,
     BPExitStatusSimulatorReuseFailed = 11,
+    BPExitStatusAppTerminatedBeforeTestStarted = 12,
 };
 
 @protocol BPExitStatusProtocol <NSObject>

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Reporters/BPExitStatus.m
@@ -38,6 +38,8 @@
             return @"BPExitStatusSimulatorDeleted";
         case BPExitStatusSimulatorReuseFailed:
             return @"BPExitStatusSimulatorReuseFailed";
+        case BPExitStatusAppTerminatedBeforeTestStarted:
+            return @"BPExitStatusAppTerminatedBeforeTestStarted";
         default:
             return @"UNKNOWN_BPEXITSTATUS";
     }

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorMonitor.m
@@ -202,14 +202,15 @@
                 [BPUtils printInfo:CRASH withString:@"%@/%@ crashed app.",
                  (self.currentClassName ?: self.previousClassName),
                  (self.currentTestName ?: self.previousTestName)];
+                self.exitStatus = BPExitStatusAppCrashed;
             } else {
                 assert(__self.testsState == Idle);
                 [BPUtils printInfo:CRASH withString:@"App crashed before tests started."];
+                self.exitStatus = BPExitStatusAppTerminatedBeforeTestStarted;
             }
             [self stopTestsWithErrorMessage:@"App Crashed"
                                 forTestName:(self.currentTestName ?: self.previousTestName)
                                     inClass:(self.currentClassName ?: self.previousClassName)];
-            self.exitStatus = BPExitStatusAppCrashed;
             [[BPStats sharedStats] addApplicationCrash];
         }
     }

--- a/Bluepill.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Bluepill.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
when app is terminated before test start, and then retry passed, we return the final status as pass. This is due to a bug introduce with Xcode 10 where it causes timeout establish a control session.