### PR TITLE
Fix clone-simulator when provided an appBundlePath

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
+++ b/Bluepill-cli/Bluepill-cli/Simulator/BPSimulator.m
@@ -46,7 +46,7 @@
     if (self.config.appBundlePath) {
         // This is for integration testing for bluepill and bluepill-cli when we assign self.config.appBundlePath
         simulatorUDIDString = [self installApplicationWithHost:self.config.appBundlePath withError:error];
-        if (!simulatorUDIDString || !error) {
+        if (!simulatorUDIDString || error) {
             [BPUtils printInfo:ERROR withString:@"Create simualtor and install application failed with error: %@", error];
             return FALSE;
         }


### PR DESCRIPTION
Good afternoon,

First off, thanks so much for creating bluepill - loving the features and capabilities this unlocks 👍 .

I'm hoping to use `clone-simulator` and ran into this bug, which seemed like an unintentional error.

Cheers!