### PR TITLE
Fix a failure where a failing test would hang (fixes Earl Grey tests)

### DIFF
--- a/BPSampleApp/BPAppNegativeTests/BPAppNegativeTests.m
+++ b/BPSampleApp/BPAppNegativeTests/BPAppNegativeTests.m
@@ -48,4 +48,27 @@
     [NSException raise:@"Invalid foo value" format:@"foo of %d is invalid", 1];
 }
 
+- (NSString *)randomStringOfLength: (NSInteger)length {
+    NSString *alphabet  = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY0123456789";
+    NSMutableString *s = [NSMutableString stringWithCapacity:length];
+    for (NSUInteger i = 0U; i < length; i++) {
+        u_int32_t r = arc4random() % [alphabet length];
+        unichar c = [alphabet characterAtIndex:r];
+        [s appendFormat:@"%C", c];
+    }
+    return s;
+}
+
+- (void)testBPDoesNotHangWithBigOutput {
+    // we want to exceed the internal buffer of a named pipe
+    NSMutableArray *lines = [[NSMutableArray alloc] init];
+    for (int i = 0; i < 1024 ; ++i) {
+        [lines addObject:[self randomStringOfLength:128]];
+    }
+    NSString *all = [NSString stringWithFormat:@"%@\n", [lines componentsJoinedByString:@"\n"]];
+    // we want a single write that puts all the data out
+    XCTAssert(false, @"%@", all);
+}
+
+
 @end

--- a/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
+++ b/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
@@ -123,6 +123,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "BPSampleAppTestWithLotsOfOutput">
+               </Test>
+               <Test
                   Identifier = "BPSampleAppTests/testCase002">
                </Test>
                <Test
@@ -192,6 +195,16 @@
                BlueprintIdentifier = "BAFCCA5C1E36DC2000E33C31"
                BuildableName = "BPSampleAppUITests.xctest"
                BlueprintName = "BPSampleAppUITests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C40B277022492E5200FAAF67"
+               BuildableName = "BPSampleAppTestsBugs.xctest"
+               BlueprintName = "BPSampleAppTestsBugs"
                ReferencedContainer = "container:BPSampleApp.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -376,6 +376,22 @@
     XCTAssert(exitCode == BPExitStatusTestsAllPassed);
 }
 
+- (void)testRunWithFailingTestsSet {
+    NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    self.config.failureTolerance = @0;
+    self.config.testCaseTimeout = @10;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppFailingTestsSetTempDir", tempDir] withError:&error];
+    // NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+    self.config.junitOutput = YES;
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssert(exitCode != BPExitStatusTestTimeout);
+    XCTAssert(exitCode == BPExitStatusTestsFailed);
+}
+
 //simulator shouldn't be kept in this case
 - (void)testKeepSimulatorWithAppCrashingTestsSet  {
     NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];

--- a/Bluepill-cli/BPInstanceTests/BluepillTests.m
+++ b/Bluepill-cli/BPInstanceTests/BluepillTests.m
@@ -312,6 +312,7 @@
     self.config.outputDirectory = outputDir;
     self.config.junitOutput = YES;
     self.config.saveDiagnosticsOnError = YES;
+    self.config.testCasesToSkip = @[@"BPAppNegativeTests/testBPDoesNotHangWithBigOutput"];
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     // Make sure all tests started on the first run
     NSString *simulator1Path = [outputDir stringByAppendingPathComponent:@"1-simulator.log"];
@@ -381,6 +382,7 @@
     self.config.testBundlePath = testBundlePath;
     self.config.failureTolerance = @0;
     self.config.testCaseTimeout = @10;
+    self.config.testCasesToRun = @[@"BPAppNegativeTests/testBPDoesNotHangWithBigOutput"];
     NSString *tempDir = NSTemporaryDirectory();
     NSError *error;
     NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppFailingTestsSetTempDir", tempDir] withError:&error];

--- a/Bluepill-cli/BPInstanceTests/Resource Files/BPAppNegativeTests-results.xml
+++ b/Bluepill-cli/BPInstanceTests/Resource Files/BPAppNegativeTests-results.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="All tests" tests="3" failures="0" errors="2">
+<testsuites name="Selected tests" tests="3" failures="0" errors="2">
     <testsuite tests="3" failures="0" errors="2" name="BPAppNegativeTests.xctest">
         <testsuite tests="3" failures="0" errors="2" name="BPAppNegativeTests">
             <testcase classname="BPAppNegativeTests" name="testAssertFailure">

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -118,7 +118,7 @@
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
-    XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 7);
+    XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 8);
     XCTAssert(rc != 0); // this runs tests that fail
 }
 

--- a/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
@@ -121,16 +121,16 @@
     self.config.numSims = @4;
     self.config.noSplit = @[@"BPSampleAppTests"];
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];// withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
-    // When we prevent BPSampleTests from splitting, BPSampleAppFatalErrorTests gets split in two
+    // When we prevent BPSampleTests from splitting, BPSampleAppFatalErrorTests and BPAppNegativeTests gets split in two
     want = [[want arrayByAddingObject:@"BPSampleAppFatalErrorTests"] sortedArrayUsingSelector:@selector(compare:)];
-    XCTAssertEqual(bundles.count, app.testBundles.count + 1);
+    XCTAssertEqual(bundles.count, app.testBundles.count + 2);
 
     XCTAssertEqual([bundles[0].skipTestIdentifiers count], 0);
     XCTAssertEqual([bundles[1].skipTestIdentifiers count], 0);
     XCTAssertEqual([bundles[2].skipTestIdentifiers count], 0);
-    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 0);
-    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 2);
-    XCTAssertEqual([bundles[5].skipTestIdentifiers count], 3);
+    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 2);
+    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 3);
+    XCTAssertEqual([bundles[5].skipTestIdentifiers count], 1);
 
     self.config.numSims = @4;
     self.config.noSplit = nil;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -609,6 +609,9 @@ static NSUUID *sessionID;
 
 - (BOOL)validateConfigWithError:(NSError *__autoreleasing *)errPtr {
     BOOL isdir;
+
+    [BPUtils enableDebugOutput:self.verboseLogging];
+
     if (!self.xcodePath) {
         self.xcodePath = [BPUtils runShell:@"/usr/bin/xcode-select -print-path"];
     }

--- a/Source/Shared/BPUtils.m
+++ b/Source/Shared/BPUtils.m
@@ -153,11 +153,14 @@ static BOOL quiet = NO;
         if (config.testCasesToRun) {
             [testsToRun unionSet:[NSSet setWithArray:[BPUtils expandTests:config.testCasesToRun withTestFile:xctFile]]];
         }
-        if (config.testCasesToSkip) {
-            [testsToSkip unionSet:[NSSet setWithArray:[BPUtils expandTests:config.testCasesToSkip withTestFile:xctFile]]];
+        if (config.testCasesToSkip || xctFile.skipTestIdentifiers) {
+            NSMutableArray *allToSkip = [NSMutableArray new];
+            [allToSkip addObjectsFromArray:config.testCasesToSkip];
+            [allToSkip addObjectsFromArray:xctFile.skipTestIdentifiers];
+            [testsToSkip unionSet:[NSSet setWithArray:[BPUtils expandTests:allToSkip withTestFile:xctFile]]];
         }
     }
-    
+
     if (testsToRun.allObjects.count > 0) {
         config.testCasesToRun = testsToRun.allObjects;
     }

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -110,8 +110,6 @@ bluepill_instance_tests()
 
   if ! grep '\*\* TEST SUCCEEDED \*\*' result.txt; then
     echo 'Test failed'
-    echo Dumping result.txt for details
-    cat result.txt
     exit 1
   fi
 }
@@ -125,8 +123,6 @@ bluepill_runner_tests()
 
   if ! grep '\*\* TEST SUCCEEDED \*\*' result.txt; then
     echo 'Test failed'
-    echo Dumping result.txt for details
-    cat result.txt
     exit 1
   fi
 }


### PR DESCRIPTION
Remove pipe for communication between app and bp
    
This fixes a bug where if the output of a failed test was too big, then bp would deadlock with the app and think the app was hung. It would essentially turn a test failure into a timeout.
   
Rather than worry about the corners of properly synchronizing over a named pipe, I just have the app log to a file and wire the parser to read from that file.

This was very apparent when using Earl Grey because the failures include full stack traces and UI hierarchy dumps.

This PR also includes two other small bug fixes:
1. verbose logging wasn't working (`-v`) options
2. The `skipTestIdentifiers` property in the `xctestrun` file wasn't being honored.