### PR TITLE
Validating the numSims configuration and adjusting it when needed

### DIFF
--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -214,8 +214,9 @@ maxprocs(void)
     }
     if (bundles.count < numSims) {
         [BPUtils printInfo:WARNING
-                withString:@"Lowering number of parallel simulators from %lu to %lu because there aren't enough tests.",
+                withString:@"Lowering number of parallel simulators from %lu to %lu because there aren't enough test bundles.",
                             numSims, bundles.count];
+        numSims = bundles.count;
     }
     if (self.config.cloneSimulator) {
         self.testHostForSimUDID = [bpSimulator createSimulatorAndInstallAppWithBundles:xcTestFiles];
@@ -223,8 +224,8 @@ maxprocs(void)
             return 1;
         }
     }
-    [BPUtils printInfo:INFO withString:@"Running with %lu parallel simulator%s.",
-     (unsigned long)numSims, (numSims > 1) ? "s" : ""];
+    [BPUtils printInfo:INFO withString:@"Running with %lu %s.",
+     (unsigned long)numSims, (numSims > 1) ? "parallel simulators" : "simulator"];
     NSArray *copyBundles = [NSMutableArray arrayWithArray:bundles];
     for (int i = 1; i < [self.config.repeatTestsCount integerValue]; i++) {
         [bundles addObjectsFromArray:copyBundles];

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -475,6 +475,10 @@ static NSUUID *sessionID;
             }
         }
     }
+    if (self.numSims.integerValue < 1) {
+        BP_SET_ERROR(errPtr, @"Number of simulators set to %lu but there cannot be fewer than one simulator.", self.numSims.integerValue);
+        return NO;
+    }
     // Pull out two keys that are undocumented but needed for supporting xctest
     self.commandLineArguments = [configDict objectForKey:@"commandLineArguments"];
     self.environmentVariables = [configDict objectForKey:@"environmentVariables"];


### PR DESCRIPTION
Two minor fixes:
1. Fewer simulators can be used if the number of bundles is less than the number of simulators.
2. There cannot be fewer than one simulator. Throw an error in case of a bad configuration (before it could possibly result in a divide-by-zero exception [here](https://github.com/linkedin/bluepill/blob/master/bluepill/src/BPPacker.m#L50)).

\cc @ob 