### PR TITLE
Fix wrong exit status

### DIFF
--- a/BPSampleApp/BPSampleAppCrashingTests/BPSampleAppCrashingTests.m
+++ b/BPSampleApp/BPSampleAppCrashingTests/BPSampleAppCrashingTests.m
@@ -15,6 +15,21 @@
 
 @implementation BPSampleAppCrashingTests
 
+NSString *attemptFromSimulatorVersionInfo(NSString *simulatorVersionInfo) {
+    // simulatorVersionInfo is something like
+    // CoreSimulator 587.35 - Device: BP93497-2-2 (7AB3D528-5473-401A-B23E-2E2E86C73861) - Runtime: iOS 12.2 (16E226) - DeviceType: iPhone 7
+    NSArray<NSString *> *parts = [simulatorVersionInfo componentsSeparatedByString:@" - "];
+    NSString *deviceString = parts[1];
+    // Device: BP93497-2-2 (7AB3D528-5473-401A-B23E-2E2E86C73861)
+    parts = [deviceString componentsSeparatedByString:@" "];
+    NSString *device = parts[1];
+    // BP93497-2-2
+    parts = [device componentsSeparatedByString:@"-"];
+    NSString *attempt = parts[1];
+    return attempt;
+
+}
+
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -31,6 +46,17 @@
 }
 
 - (void)testAppCrash1 {
+    NSDictionary *env = [[NSProcessInfo processInfo] environment];
+    NSString *simulatorVersionInfo = [env objectForKey:@"SIMULATOR_VERSION_INFO"];
+    NSString *attempt = attemptFromSimulatorVersionInfo(simulatorVersionInfo);
+    NSString *crashOnAttempt = [env objectForKey:@"_BP_TEST_CRASH_ON_ATTEMPT"];
+
+    NSLog(@"Attempt: %@ Crash requested on %@, not crashing", attempt, crashOnAttempt);
+    if (crashOnAttempt && crashOnAttempt != attempt) {
+        return;
+    }
+
+    // ok, let's crash and burn
     int *pointer = nil;
     *pointer = 1;
 }

--- a/BPSampleApp/BPSampleAppCrashingTests/BPSampleAppCrashingTests.m
+++ b/BPSampleApp/BPSampleAppCrashingTests/BPSampleAppCrashingTests.m
@@ -51,11 +51,12 @@ NSString *attemptFromSimulatorVersionInfo(NSString *simulatorVersionInfo) {
     NSString *attempt = attemptFromSimulatorVersionInfo(simulatorVersionInfo);
     NSString *crashOnAttempt = [env objectForKey:@"_BP_TEST_CRASH_ON_ATTEMPT"];
 
-    NSLog(@"Attempt: %@ Crash requested on %@, not crashing", attempt, crashOnAttempt);
+    NSLog(@"Attempt: %@ Crash requested on %@", attempt, crashOnAttempt);
     if (crashOnAttempt && crashOnAttempt != attempt) {
+        NSLog(@"not crashing");
         return;
     }
-
+    NSLog(@"crashing");
     // ok, let's crash and burn
     int *pointer = nil;
     *pointer = 1;

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -90,6 +90,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic) BOOL testing_CrashAppOnLaunch;
 @property (nonatomic) BOOL testing_HangAppOnLaunch;
 @property (nonatomic) BOOL testing_NoAppWillRun;
+@property (nonatomic) NSNumber *testing_crashOnAttempt;
 
 // Generated fields
 @property (nonatomic, strong) NSString *xcodePath;

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -331,6 +331,7 @@ static NSUUID *sessionID;
     newConfig.testing_CrashAppOnLaunch = self.testing_CrashAppOnLaunch;
     newConfig.testing_HangAppOnLaunch = self.testing_HangAppOnLaunch;
     newConfig.testing_NoAppWillRun = self.testing_NoAppWillRun;
+    newConfig.testing_crashOnAttempt = self.testing_crashOnAttempt;
     newConfig.xcTestRunPath = self.xcTestRunPath;
     newConfig.xcTestRunDict = self.xcTestRunDict;
     newConfig.commandLineArguments = self.commandLineArguments;

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -473,6 +473,9 @@
     if (self.config.testing_HangAppOnLaunch) {
         appLaunchEnvironment[@"_BP_TEST_HANG_ON_LAUNCH"] = @"YES";
     }
+    if (self.config.testing_crashOnAttempt) {
+        appLaunchEnvironment[@"_BP_TEST_CRASH_ON_ATTEMPT"] = [self.config.testing_crashOnAttempt stringValue];
+    }
 
     // Intercept stdout, stderr and post as simulator-output events
     NSString *stdout_stderr = [NSString stringWithFormat:@"%@/tmp/stdout_stderr_%@", self.device.dataPath, [[self.device UDID] UUIDString]];

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -600,7 +600,7 @@ static void onInterrupt(int ignore) {
 
     if (![self hasRemainingTestsInContext:context] && (context.attemptNumber <= [context.config.errorRetriesCount integerValue])) {
         [BPUtils printInfo:INFO withString:@"No more tests to run."];
-        self.finalExitStatus = context.finalExitStatus | context.exitStatus;
+        self.finalExitStatus = context.exitStatus;
         self.exitLoop = YES;
         return;
     }

--- a/bp/tests/BluepillTests.m
+++ b/bp/tests/BluepillTests.m
@@ -232,6 +232,23 @@
     [self assertGotReport:junitReportPath isEqualToWantReport:expectedFilePath];
 }
 
+- (void)testAppCrashingAndRetryReportsCorrectExitCode {
+    NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppCrashingTestsSetTempDir", tempDir] withError:&error];
+    // NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+    self.config.testing_crashOnAttempt = @1;
+    self.config.errorRetriesCount = @2;
+    self.config.failureTolerance = @1;
+    self.config.onlyRetryFailed = YES;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusTestsAllPassed);
+}
+
 - (void)testReportWithFatalErrorTestsSet {
     NSString *testBundlePath = [BPTestHelper sampleAppFatalTestsBundlePath];
     self.config.testBundlePath = testBundlePath;

--- a/bp/tests/BluepillTests.m
+++ b/bp/tests/BluepillTests.m
@@ -238,7 +238,6 @@
     NSString *tempDir = NSTemporaryDirectory();
     NSError *error;
     NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppCrashingTestsSetTempDir", tempDir] withError:&error];
-    // NSLog(@"output directory is %@", outputDir);
     self.config.outputDirectory = outputDir;
     self.config.testing_crashOnAttempt = @1;
     self.config.errorRetriesCount = @2;


### PR DESCRIPTION
When a test crashed and then passed in a retry, bp was still
reporting the crash in the exit status. This fixes it.