### PR TITLE
Fixed setupWeakLinking asserting if bluepill is launched without a full executable path

### DIFF
--- a/bluepill/src/main.m
+++ b/bluepill/src/main.m
@@ -57,7 +57,7 @@ struct options {
 
 int main(int argc, char * argv[]) {
     @autoreleasepool {
-        int rc = [BPUtils setupWeakLinking:argv];
+        int rc = [BPUtils setupWeakLinking:argc argv:argv];
         if (rc != 0) {
             return rc;
         }

--- a/bp/src/BPUtils.h
+++ b/bp/src/BPUtils.h
@@ -149,10 +149,11 @@ typedef BOOL (^BPRunBlock)(void);
 
 /*!
  * @discussion setup the environment for weak linked frameworks
+ * @param argc the number of arguments to the command
  * @param argv the arguments to the command
  * @return exit code 0 == success
  */
-+ (int)setupWeakLinking:(char **)argv;
++ (int)setupWeakLinking:(int)argc argv:(char **)argv;
 
 /*!
  * @discussion return the version of bplib

--- a/bp/src/BPUtils.m
+++ b/bp/src/BPUtils.m
@@ -292,7 +292,7 @@ static BOOL quiet = NO;
     return BP_VERSION;
 }
 
-+ (int)setupWeakLinking:(char **)argv {
++ (int)setupWeakLinking:(int)argc argv:(char **)argv {
     // This next part is because we're weak-linking the private Xcode frameworks.
     // This is necessary in case you have multiple versions of Xcode so we dynamically
     // look at the path where Xcode is and add the private framework paths to the
@@ -333,9 +333,19 @@ static BOOL quiet = NO;
     NSString *fallbackFrameworkPath = [fallbackFrameworkPaths componentsJoinedByString:@":"];
     setenv("DYLD_FALLBACK_FRAMEWORK_PATH", [fallbackFrameworkPath UTF8String], 1);
 
+    // Rewrite argv with the full path to the executable
+    const char *updatedArgv[argc + 1];
+
+    updatedArgv[0] = [[[NSBundle mainBundle] executablePath] fileSystemRepresentation];
+    updatedArgv[argc] = 0;
+
+    for (int i = 1; i < argc; i++) {
+        updatedArgv[i] = argv[i];
+    }
+
     // Don't do this setup again...
     setenv("BP_DYLD_RESOLVED", "YES", 1);
-    execv(argv[0], (char *const *)argv);
+    execv(updatedArgv[0], (char *const *)updatedArgv);
 
     // we should never get here
     assert(!"FAIL");

--- a/bp/src/main.m
+++ b/bp/src/main.m
@@ -21,7 +21,7 @@
 
 int main(int argc, char * argv[]) {
     @autoreleasepool {
-        int rc = [BPUtils setupWeakLinking:argv];
+        int rc = [BPUtils setupWeakLinking:argc argv:argv];
         if (rc != 0) return rc;
 #pragma mark main
         int c;


### PR DESCRIPTION
Pass argc and argv and then rewrite argv so the first argument uses the full path to the executable.

Otherwise running bluepill from a shell will fail because `argv[0]` will be just `bluepill` rather than the full path to the executable.

Introduced in #327.