### PR TITLE
Logging cleanups

### DIFF
--- a/bluepill/src/BPApp.m
+++ b/bluepill/src/BPApp.m
@@ -79,7 +79,7 @@
                                                                andXcodePath:xcodePath
                                                                    andError:errPtr];
         if (!xcTestFile) {
-            [BPUtils printInfo:ERROR withString:@"Failed to read data for %@", key];
+            [BPUtils printError:nil withString:@"Failed to read data for %@", key];
             errorCount++;
             continue;
         }

--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -48,7 +48,7 @@
                                          includingPropertiesForKeys:keys
                                          options:0
                                          errorHandler:^(NSURL *url, NSError *error) {
-                                             [BPUtils printInfo:ERROR withString:@"Failed to process url %@: %@", url, [error localizedDescription]];
+                                             [BPUtils printError:error withString:@"Failed to process url %@", url];
                                              return YES;
                                          }];
     NSMutableData *traceData = nil;
@@ -58,7 +58,7 @@
         NSError *error;
         NSNumber *isDirectory = nil;
         if (![url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
-            [BPUtils printInfo:ERROR withString:@"Failed to get resource from url %@", url];
+            [BPUtils printError:nil withString:@"Failed to get resource from url %@", url];
         }
         else if (![isDirectory boolValue]) {
             if ([[url pathExtension] isEqualToString:@"xml"]) {
@@ -66,7 +66,7 @@
                 NSString *path = [url path];
                 NSDictionary *fileAttrs = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:&error];
                 if (error) {
-                    [BPUtils printInfo:ERROR withString:@"Failed to get attributes for '%@': %@", path, [error localizedDescription]];
+                    [BPUtils printError:error withString:@"Failed to get attributes for '%@'", path];
                     continue;
                 }
                 NSDate *mtime = [fileAttrs objectForKey:NSFileModificationDate];
@@ -118,8 +118,8 @@
         @autoreleasepool {
             NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];
             if (err) {
-                [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
-                [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];
+                [BPUtils printError:err withString:@"Failed to parse '%@'", [[report url] path]];
+                [BPUtils printError:nil withString:@"SOME TESTS MIGHT BE MISSING"];
                 continue;
             }
             // grab all the test suites
@@ -177,7 +177,7 @@
     } else if ([firstChild isEqualToString:@"testcase"]) {
         [self collateTestSuiteTestCases:testSuite into:targetTestSuite];
     } else if (firstChild) { // empty
-        [BPUtils printInfo:ERROR withString:@"Unknown child node in '%@': %@", [[testSuite attributeForName:@"name"] stringValue],  firstChild];
+        [BPUtils printError:nil withString:@"Unknown child node in '%@': %@", [[testSuite attributeForName:@"name"] stringValue],  firstChild];
         assert(false);
     }
 }

--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -180,7 +180,7 @@ maxprocs(void)
                                  configuration:configuration
                                  error:errPtr];
     if (!app) {
-        [BPUtils printInfo:ERROR withString:@"Launch Simulator.app returned error: %@", [*errPtr localizedDescription]];
+        [BPUtils printError:*errPtr withString:@"Launch Simulator.app failed"];
         return nil;
     }
     return app;
@@ -194,13 +194,13 @@ maxprocs(void)
     new_action.sa_flags = 0;
 
     if (sigaction(SIGINT, &new_action, NULL) != 0) {
-        [BPUtils printInfo:ERROR withString:@"Could not install SIGINT handler: %s", strerror(errno)];
+        [BPUtils printError:nil withString:@"Could not install SIGINT handler: %s", strerror(errno)];
     }
     if (sigaction(SIGTERM, &new_action, NULL) != 0) {
-        [BPUtils printInfo:ERROR withString:@"Could not install SIGTERM handler: %s", strerror(errno)];
+        [BPUtils printError:nil withString:@"Could not install SIGTERM handler: %s", strerror(errno)];
     }
     if (sigaction(SIGHUP, &new_action, NULL) != 0) {
-        [BPUtils printInfo:ERROR withString:@"Could not install SIGHUP handler: %s", strerror(errno)];
+        [BPUtils printError:nil withString:@"Could not install SIGHUP handler: %s", strerror(errno)];
     }
 
     BPSimulator *bpSimulator = [BPSimulator simulatorWithConfiguration:self.config];
@@ -209,7 +209,7 @@ maxprocs(void)
     NSError *error;
     NSMutableArray *bundles = [BPPacker packTests:xcTestFiles configuration:self.config andError:&error];
     if (!bundles || bundles.count == 0) {
-        [BPUtils printInfo:ERROR withString:@"Packing failed: %@", [error localizedDescription]];
+        [BPUtils printError:error withString:@"Packing failed"];
         return 1;
     }
     if (bundles.count < numSims) {
@@ -245,14 +245,14 @@ maxprocs(void)
     if (_config.headlessMode == NO) {
         app = [self openSimulatorAppWithConfiguration:_config andError:&error];
         if (!app) {
-            [BPUtils printInfo:ERROR withString:@"Could not launch Simulator.app due to error: %@", [error localizedDescription]];
+            [BPUtils printError:error withString:@"Could not launch Simulator.app"];
             return -1;
         }
     }
     while (1) {
         if (interrupted) {
             if (interrupted >=5) {
-                [BPUtils printInfo:ERROR withString:@"You really want to terminate, OK!"];
+                [BPUtils printError:nil withString:@"You really want to terminate, OK!"];
                 exit(0);
             }
             if (interrupted != old_interrupted) {
@@ -288,7 +288,7 @@ maxprocs(void)
                 rc = (rc || [task terminationStatus]);
             }];
             if (!task) {
-                [BPUtils printInfo:ERROR withString:@"task is nil!"];
+                [BPUtils printError:nil withString:@"task is nil!"];
                 exit(1);
             }
             [task launch];
@@ -388,7 +388,7 @@ maxprocs(void)
         lastUserTime = totalUserTime;
         lastIdleTime = totalIdleTime;
     } else {
-        [BPUtils printInfo:ERROR withString:@"Failed to get CPU stats: %s", mach_error_string(kr)];
+        [BPUtils printError:nil withString:@"Failed to get CPU stats: %s", mach_error_string(kr)];
     }
     // get memory info
     count = HOST_VM_INFO_COUNT;
@@ -408,7 +408,7 @@ maxprocs(void)
                                                                  @"free": @(free * 100.0f)
                                                                  }];
     } else {
-        [BPUtils printInfo:ERROR withString:@"Failed to get Memory info: %s", mach_error_string(kr)];
+        [BPUtils printError:nil withString:@"Failed to get Memory info: %s", mach_error_string(kr)];
     }
 }
 

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
  
  @return An instance of `BPConfiguration` on success. Nil on failure.
  */
-- (instancetype)initWithProgram:(int)program;
+- (instancetype)initWithProgram:(BPProgram)program;
 
 /**
  Create a new configuration object based on the given configuration file. 

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -148,7 +148,7 @@ static NSUUID *sessionID;
 
 #pragma mark instance methods
 
-- (instancetype)initWithProgram:(int)program {
+- (instancetype)initWithProgram:(BPProgram)program {
     return [self initWithConfigFile:nil forProgram:program withError:nil];
 }
 
@@ -299,13 +299,13 @@ static NSUUID *sessionID;
                                                        options:NSJSONWritingPrettyPrinted
                                                          error:&err];
         if (!json) {
-            [BPUtils printInfo:ERROR withString:@"%@", err];
+            [BPUtils printError:err withString:@""];
             return nil;
         }
         NSString *jsonString = [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding];
         return jsonString;
     } else {
-        [BPUtils printInfo:ERROR withString:@"Error: configuration not serializable."];
+        [BPUtils printError:nil withString:@"Error: configuration not serializable."];
     }
     return nil;
 }
@@ -727,8 +727,8 @@ static NSUUID *sessionID;
     self.simDeviceType = nil;
     SimServiceContext *sc = [SimServiceContext sharedServiceContextForDeveloperDir:self.xcodePath error: errPtr];
     if (!sc) {
-        [BPUtils printInfo:ERROR withString:@"Failed to initialize SimServiceContext: %@", *errPtr];
-        [BPUtils printInfo:ERROR withString:@"self.xcodePath is: %@", self.xcodePath];
+        [BPUtils printError:*errPtr withString:@"Failed to initialize SimServiceContext"];
+        [BPUtils printInfo:DEBUGINFO withString:@"self.xcodePath is: %@", self.xcodePath];
         return NO;
     }
 

--- a/bp/src/BPExitStatus.h
+++ b/bp/src/BPExitStatus.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSInteger, BPExitStatus) {
+typedef NS_ENUM(int, BPExitStatus) {
     BPExitStatusTestsAllPassed = 0,
     BPExitStatusTestsFailed = 1,
     BPExitStatusSimulatorCreationFailed = 2,

--- a/bp/src/BPStats.m
+++ b/bp/src/BPStats.m
@@ -83,7 +83,7 @@
 - (void)endTimer:(NSString *)name withResult:(NSString *) result {
     BPStat *stat = [self statForName:name createIfNotExist:NO];
     if (!stat) {
-        [BPUtils printInfo:ERROR withString:@"EndTimerFailure: EndTimer called without starting a timer for '%@'", name];
+        [BPUtils printError:nil withString:@"EndTimerFailure: EndTimer called without starting a timer for '%@'", name];
 #ifdef DEBUG
         [NSException raise:@"EndTimerFailure" format:@"EndTimer called without starting a timer for '%@'", name];
 #endif
@@ -104,7 +104,7 @@
 - (NSString *)getJsonStat:(NSString *)name {
     BPStat *stat = [self statForName:name createIfNotExist:NO];
     if (!stat) {
-        [BPUtils printInfo:ERROR withString:@"OutputTimerState called without starting a timer for '%@'", name];
+        [BPUtils printError:nil withString:@"OutputTimerState called without starting a timer for '%@'", name];
 #ifdef DEBUG
         [NSException raise:@"OutputTimerFailure" format:@"OutputTimerState called without starting a timer for '%@'", name];
 #endif

--- a/bp/src/BPTestDaemonConnection.m
+++ b/bp/src/BPTestDaemonConnection.m
@@ -59,7 +59,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
         return self.connected;
     }];
     if (!self.connected) {
-        [BPUtils printInfo:ERROR withString:@"Timeout establishing a control session!"];
+        [BPUtils printError:nil withString:@"Timeout establishing a control session!"];
     }
 }
 
@@ -80,7 +80,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     DTXRemoteInvocationReceipt *receipt = [daemonProxy _IDE_initiateControlSessionForTestProcessID:@(self.testRunnerPid) protocolVersion:@(BP_DAEMON_PROTOCOL_VERSION)];
     [receipt handleCompletion:^(NSNumber *version, NSError *error) {
         if (error) {
-            [BPUtils printInfo:ERROR withString:@"Error with daemon connection: %@", [error localizedDescription]];
+            [BPUtils printError:error withString:@"Error with daemon connection"];
             return;
         }
         NSInteger daemonProtocolVersion = version.integerValue;
@@ -99,7 +99,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     strncpy(remote.sun_path, socketPath, 104);
     socklen_t length = (socklen_t)(strnlen(remote.sun_path, 1024) + sizeof(remote.sun_family) + sizeof(remote.sun_len));
     if (connect(socketFD, (struct sockaddr *)&remote, length) == -1) {
-        [BPUtils printInfo:ERROR withString:@"ERROR connecting socket"];
+        [BPUtils printError:nil withString:@"ERROR connecting socket: %s", strerror(errno)];
     }
     return socketFD;
 }

--- a/bp/src/BPTreeParser.m
+++ b/bp/src/BPTreeParser.m
@@ -99,7 +99,7 @@ static const NSString * const kPassed = @"passed";
             [BPUtils printInfo:WARNING withString:@"ASCII: %@", str];
         }
         if (!str) {
-            [BPUtils printInfo:ERROR withString:@"Failed to ASCII decode chunk: %@", chunk];
+            [BPUtils printError:nil withString:@"Failed to ASCII decode chunk: %@", chunk];
             exit(1);
         }
         NSRange range = [str rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
@@ -110,9 +110,9 @@ static const NSString * const kPassed = @"passed";
             [self.log writeLine:@"%@", self.line];
             [self parseLine:self.line];
             if (numLines++ > maxLines) {
-                [BPUtils printInfo:ERROR withString:@"Infinite Loop Averted!: range {%lu, %lu}, %lu, %@",
+                [BPUtils printError:nil withString:@"Infinite Loop Averted!: range {%lu, %lu}, %lu, %@",
                  (unsigned long)range.length, (unsigned long)range.location, (unsigned long)[chunk length], str];
-                [BPUtils printInfo:ERROR withString:@"Data: %@", chunk];
+                [BPUtils printError:nil withString:@"Data: %@", chunk];
                 // Fail hard.
                 exit(1);
             }
@@ -232,7 +232,7 @@ static const NSString * const kPassed = @"passed";
                 } else if (([node.parent.testSuiteName isEqualToString:testSuiteName]) && node.parent.ended == NO) {
                     self.current = node.parent;
                 } else {
-                    [BPUtils printInfo:ERROR withString:
+                    [BPUtils printError:nil withString:
                      @"ERROR: WHERE ARE WE??? We're closing a node for a test suite that hasn't been started [Expected: %@, Current: %@]. Ended: %@\nProblem line: %@",
                       testSuiteName,
                       node.testSuiteName,
@@ -288,7 +288,7 @@ static const NSString * const kPassed = @"passed";
                 testCaseLogEntry.failure = NO; // failure means app crashed
                 testCaseLogEntry.errorMessage = errorMessage;
             } else {
-                [BPUtils printInfo:ERROR withString:
+                [BPUtils printError:nil withString:
                  @"HOW DID WE GET AN ERROR THAT WASN'T PARSED? We received an error in a test case that wasn't started or did not parse properly.\nProblem line: %@",
                   line];
             }
@@ -456,7 +456,7 @@ static const NSString * const kPassed = @"passed";
                                       wasException:testCaseLogEntry.failure];
                 }
             } else {
-                [BPUtils printInfo:ERROR withString:
+                [BPUtils printError:nil withString:
                  @"HOW ON EARTH DID THIS HAPPEN? The test case passed but we failed to handle it properly\nProblem line: %@",
                   line];
             }

--- a/bp/src/BPUtils.h
+++ b/bp/src/BPUtils.h
@@ -16,12 +16,13 @@ _a < _b ? _a : _b; \
 
 #import <Foundation/Foundation.h>
 
+// The order here needs to match the order in the Messages struct
+// in BPUtils.m
 typedef NS_ENUM(int, BPKind) {
     PASSED,
     FAILED,
     TIMEOUT,
     INFO,
-    ERROR,
     WARNING,
     CRASH,
     DEBUGINFO // DEBUG collides with a #define, so DEBUGINFO it is
@@ -75,6 +76,14 @@ typedef NS_ENUM(int, BPKind) {
  @param fmt a format string (a la printf), followed by the var args.
  */
 + (void)printInfo:(BPKind)kind withString:(NSString *)fmt, ... NS_FORMAT_FUNCTION(2,3);
+
+/*!
+ @discussion print an error to stderr
+ @param error the NSError * to print
+ @param fmt a format string (a la printf), followed by the var args. It'll be prepended
+            to the text of the error.
+ */
++ (void)printError:(NSError *)error withString:(NSString *)fmt, ... NS_FORMAT_FUNCTION(2, 3);
 
 /*!
  @discussion get an NSError *

--- a/bp/src/BPXCTestFile.m
+++ b/bp/src/BPXCTestFile.m
@@ -134,7 +134,7 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
         NSString *platformsPath = [xcodePath stringByAppendingPathComponent:@"Platforms"];
         testBundlePath = [testBundlePath stringByReplacingOccurrencesOfString:PLATFORMS withString:platformsPath];
     } else {
-        [BPUtils printInfo:ERROR withString:@"testBundlePath is incorrect, please check xctestrun file"];
+        [BPUtils printError:nil withString:@"testBundlePath is incorrect, please check xctestrun file"];
     }
     NSString * UITargetAppPath = [dict objectForKey:@"UITargetAppPath"];
     if (UITargetAppPath) {

--- a/bp/src/SimulatorHelper.m
+++ b/bp/src/SimulatorHelper.m
@@ -151,13 +151,13 @@
     
     NSString *platform = [dic objectForKey:@"DTPlatformName"];
     if (platform && ![platform isEqualToString:@"iphonesimulator"]) {
-        [BPUtils printInfo:ERROR withString:@"Wrong platform in %@. Expected 'iphonesimulator', found '%@'", path, platform];
+        [BPUtils printError:nil withString:@"Wrong platform in %@. Expected 'iphonesimulator', found '%@'", path, platform];
         return nil;
     }
 
     NSString *bundleId = [dic objectForKey:(NSString *)kCFBundleIdentifierKey];
     if (!bundleId) {
-        [BPUtils printInfo:ERROR withString:@"Could not extract bundleID: %@", dic];
+        [BPUtils printError:nil withString:@"Could not extract bundleID: %@", dic];
     }
     return bundleId;
 }

--- a/bp/src/SimulatorMonitor.m
+++ b/bp/src/SimulatorMonitor.m
@@ -216,7 +216,7 @@
             BOOL testsReallyStarted = [__self didTestsStart];
             if (testClass == nil && testName == nil && (__self.appState == Running)) {
                 testsReallyStarted = false;
-                [BPUtils printInfo:ERROR withString:@"It appears that tests have not yet started. The test app has frozen prior to the first test."];
+                [BPUtils printError:nil withString:@"It appears that tests have not yet started. The test app has frozen prior to the first test."];
             } else {
                 [BPUtils printInfo:TIMEOUT withString:@" %10.6fs waiting for output from %@/%@",
                  __self.maxTimeWithNoOutput, testClass, testName];
@@ -240,7 +240,7 @@
         [self updateExecutedTestCaseList:testName inClass:testClass];
     }
     if (self.appState == Running && !self.config.testing_NoAppWillRun) {
-        [BPUtils printInfo:ERROR withString:@"Will kill the process with appPID: %d", self.appPID];
+        [BPUtils printError:nil withString:@"Will kill the process with appPID: %d", self.appPID];
         NSAssert(self.appPID > 0, @"Failed to find a valid PID");
         NSDateFormatter *dateFormatter=[[NSDateFormatter alloc] init];
         [dateFormatter setDateFormat:@"yyyy-MM-dd_HH-mm-ss"];
@@ -248,7 +248,7 @@
         [BPUtils printInfo:INFO withString:@"saving 'sample' command log to: %@", sampleLogFile];
         [BPUtils runShell:[NSString stringWithFormat:@"/usr/bin/sample %d -file %@", self.appPID, sampleLogFile]];
         if ((kill(self.appPID, 0) == 0) && (kill(self.appPID, SIGKILL) < 0)) {
-            [BPUtils printInfo:ERROR withString:@"Failed to kill the process with appPID: %d: %s",
+            [BPUtils printError:nil withString:@"Failed to kill the process with appPID: %d: %s",
                 self.appPID, strerror(errno)];
         }
     }


### PR DESCRIPTION
NFC: I realized we weren't printing `NSError *`'s correctly. In some cases we were printing the `localizedDescription` and in others not. However, `localizedDescription` is insufficient for determining the real cause of the error, we also have to print `localizedFailureReason`. Instead of changing a bunch of locations to fix, gather the error printing into a single function.