### PR TITLE
bptestrunner: Reverse precendence of configuration

### DIFF
--- a/bptestrunner/main.py
+++ b/bptestrunner/main.py
@@ -48,8 +48,8 @@ def main():
     bpargs += ['--xcode-path', find_xcode_path()]
     output_dir = os.environ['TEST_UNDECLARED_OUTPUTS_DIR']
     bpargs += ['--output-dir', output_dir]
-    config_file = merge_config_files(args.attr_config_file,
-                                     args.rule_config_file)
+    config_file = merge_config_files(args.rule_config_file,
+                                     args.attr_config_file)
     bpargs += ['-c', config_file]
 
     logging.debug("Running: bluepill %s", ' '.join(bpargs))


### PR DESCRIPTION
I just realized we had the precedence wrong here. The Bazel rule needs to be able to override the values in the configuration file (much like the command line arguments) instead of the other way around.