### PR TITLE
Smart splitting without duplication execution of tests

### DIFF
--- a/Bluepill-cli/BPInstanceTests/BPTestHelper.h
+++ b/Bluepill-cli/BPInstanceTests/BPTestHelper.h
@@ -53,6 +53,9 @@
 // Return path to the sample times json file.
 + (NSString *)sampleTimesJsonPath;
 
+// Return path to the sample inherited classes mapping json file.
++ (NSString *)sampleInheritedClassesJsonPath;
+
 // Return the sample photo path.
 + (NSString *)samplePhotoPath;
 

--- a/Bluepill-cli/BPInstanceTests/BPTestHelper.m
+++ b/Bluepill-cli/BPInstanceTests/BPTestHelper.m
@@ -64,6 +64,10 @@
     return [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"times.json"];
 }
 
++ (NSString *)sampleInheritedClassesJsonPath {
+    return [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"inherited.json"];
+}
+
 + (NSString *)samplePhotoPath {
     return [[[NSBundle bundleForClass:[self class]] resourcePath] stringByAppendingPathComponent:@"image.png"];
 }

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -205,8 +205,10 @@ void onInterrupt(int ignore) {
     NSString *testHostPath = context.config.testRunnerAppPath ?: context.config.appBundlePath;
     BPXCTestFile *xctTestFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:context.config.testBundlePath
                                                           andHostAppBundle:testHostPath
+                                                        andUITargetAppPath:nil
+                                                          andClassMappings:nil
                                                                  withError:&error];
-    NSAssert(xctTestFile != nil, @"Failed to load testcases from %@", [error localizedDescription]);
+    NSAssert(xctTestFile != nil, @"Failed to load testcases. Error: %@", [error localizedDescription]);
     context.config.allTestCases = [[NSArray alloc] initWithArray: xctTestFile.allTestCases];
 
 

--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -113,6 +113,8 @@
         classMappings = [BPUtils loadJsonMappingFile:config.inheritedClassMappingJsonFile withError:errorPtr];
         if ((errorPtr && *errorPtr) || !classMappings) {
             [BPUtils printInfo:ERROR withString:@"Failed to read class mappings. Error: %@", [*errorPtr localizedDescription]];
+            BP_SET_ERROR(errPtr, [*errorPtr localizedDescription]);
+            return nil;
         }
     }
     if (config.xcTestRunDict) {

--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -7,8 +7,8 @@
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
-#import <BluepillLib/BPConstants.h>
 #import "BPPacker.h"
+#import <BluepillLib/BPConstants.h>
 #import <BluepillLib/BPXCTestFile.h>
 #import <BluepillLib/BPUtils.h>
 
@@ -109,7 +109,7 @@
     }
 
     // load the config file
-    NSDictionary *testTimes = [self loadConfigFile:config.testTimeEstimatesJsonFile withError:errPtr];
+    NSDictionary *testTimes = [BPUtils loadJsonMappingFile:config.testTimeEstimatesJsonFile withError:errPtr];
     if ((errPtr && *errPtr) || !testTimes) {
         [BPUtils printInfo:ERROR withString:@"%@", [*errPtr localizedDescription]];
         return NULL;
@@ -170,14 +170,4 @@
     return sortedBundles;
 }
 
-+ (NSDictionary *)loadConfigFile:(NSString *)file withError:(NSError **)errPtr{
-    NSData *data = [NSData dataWithContentsOfFile:file
-                                          options:NSDataReadingMappedIfSafe
-                                            error:errPtr];
-    if (!data) return nil;
-
-    return [NSJSONSerialization JSONObjectWithData:data
-                                           options:kNilOptions
-                                             error:errPtr];
-}
 @end

--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -30,7 +30,6 @@
     [BPUtils printInfo:INFO withString:@"Packing test bundles based on test counts."];
     NSArray *testCasesToRun = config.testCasesToRun;
     NSArray *noSplit = config.noSplit;
-    NSUInteger numBundles = [config.numSims integerValue];
     NSArray *sortedXCTestFiles = [xcTestFiles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
         NSUInteger numTests1 = [(BPXCTestFile *)obj1 numTests];
         NSUInteger numTests2 = [(BPXCTestFile *)obj2 numTests];
@@ -58,8 +57,7 @@
             }
         }
     }
-    
-    NSUInteger testsPerGroup = MAX(1, totalTests / numBundles);
+    NSUInteger testsPerGroup = MAX(1, totalTests / [config.numSims integerValue]);
     NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
         NSArray *bundleTestsToRun = [[testsToRunByTestFilePath[xctFile.testBundlePath] allObjects] sortedArrayUsingSelector:@selector(compare:)];
@@ -115,9 +113,10 @@
         return NULL;
     }
 
-    NSMutableDictionary *estimatedTimesByTestFilePath = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *testsToRunByTestFilePath = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *testEstimatedTimesByTestFilePath = [[NSMutableDictionary alloc] init];
     NSArray *testCasesToRun = config.testCasesToRun;
-
+    [BPUtils printInfo:INFO withString:@"Test cases to run from the config: %lu", [config.testCasesToRun count]];
     double totalTime = 0.0;
     for (BPXCTestFile *xctFile in xcTestFiles) {
         NSMutableSet *bundleTestsToRun = [[NSMutableSet alloc] initWithArray:[xctFile allTestCases]];
@@ -127,7 +126,16 @@
         if (config.testCasesToSkip && [config.testCasesToSkip count] > 0) {
             [bundleTestsToRun minusSet:[[NSSet alloc] initWithArray:config.testCasesToSkip]];
         }
+        [BPUtils printInfo:INFO withString:@"Bundle: %@; All Tests count: %lu; bundleTestsToRun count: %lu; Tests: %@", xctFile.testBundlePath, (unsigned long)[xctFile.allTestCases count], (unsigned long)[bundleTestsToRun count], [xctFile allTestCases]];
+        if ([bundleTestsToRun count] != [[xctFile allTestCases] count]) {
+            NSMutableArray *allTests = [NSMutableArray arrayWithArray:[xctFile allTestCases]];
+            [BPUtils printInfo:INFO withString:@"All tests: %@", [allTests componentsJoinedByString:@","]];
+            [BPUtils printInfo:INFO withString:@"Bundle tests: %@", [[bundleTestsToRun allObjects] componentsJoinedByString:@","]];
+            [allTests removeObjectsInArray:[bundleTestsToRun allObjects]];
+            [BPUtils printInfo:INFO withString:@"Remaining tests that are not set to run: %@", [allTests componentsJoinedByString:@","]];
+        }
         if (bundleTestsToRun.count > 0) {
+            testsToRunByTestFilePath[xctFile.testBundlePath] = bundleTestsToRun;
             double __block testBundleExecutionTime = 0.0;
             [bundleTestsToRun enumerateObjectsUsingBlock:^(id _Nonnull test, BOOL * _Nonnull stop) {
                 // TODO: Assign a sensible default if the estimate is not given
@@ -137,21 +145,67 @@
                     [BPUtils printInfo:INFO withString:@"Estimate not available for %@", test];
                 }
             }];
-            estimatedTimesByTestFilePath[xctFile.testBundlePath] = [NSNumber numberWithDouble:testBundleExecutionTime];
+            testEstimatedTimesByTestFilePath[xctFile.testBundlePath] = [NSNumber numberWithDouble:testBundleExecutionTime];
             totalTime += testBundleExecutionTime;
         }
     }
-    assert([estimatedTimesByTestFilePath count] == [xcTestFiles count]);
+    assert([testEstimatedTimesByTestFilePath count] == [xcTestFiles count]);
 
-    NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
-    for (BPXCTestFile *xctFile in xcTestFiles) {
-        BPXCTestFile *bundle = [xctFile copy];
-        bundle.skipTestIdentifiers = config.testCasesToSkip;
-        [bundle setEstimatedExecutionTime:estimatedTimesByTestFilePath[xctFile.testBundlePath]];
-        [bundles addObject:bundle];
+    [BPUtils printInfo:INFO withString:@"Stats before splitting..."];
+    NSMutableDictionary *inputDic = [NSMutableDictionary dictionary];
+    for(id key in testEstimatedTimesByTestFilePath) {
+        inputDic[[key substringFromIndex:[(NSString *)key rangeOfString:@"/" options:NSBackwardsSearch].location+1]] = [testEstimatedTimesByTestFilePath objectForKey:key];
+        NSLog(@"%@ = %@", [key substringFromIndex:[(NSString *)key rangeOfString:@"/" options:NSBackwardsSearch].location+1], [testEstimatedTimesByTestFilePath objectForKey:key]);
     }
+
+    int minimumBundleTime = 180;
+    NSUInteger maxBundleTime = MAX(minimumBundleTime, totalTime / [config.numSims integerValue]);
+    [BPUtils printInfo:INFO withString:@"Max Bundle Time is around %lu seconds.", maxBundleTime];
+
+    // TODO: First of all check if the bundles need to be split or not (Hint: Based on numSims, current test bundle count and standard deviation of their execution times)
+    NSMutableArray<BPXCTestFile *> *testBundles = [[NSMutableArray alloc] init];
+    for (BPXCTestFile *xctFile in xcTestFiles) {
+        NSArray *bundleTestsToRun = [[testsToRunByTestFilePath[xctFile.testBundlePath] allObjects] sortedArrayUsingSelector:@selector(compare:)];
+        double bundleEstimate = [testEstimatedTimesByTestFilePath[xctFile.testBundlePath] doubleValue];
+        if (bundleEstimate > maxBundleTime) {
+            NSUInteger packed = 0;
+            double splitExecTime = 0.0;
+            double sumOfSplits = 0.0;
+            for (int i = 0; i < [bundleTestsToRun count];) {
+                NSString *test = [bundleTestsToRun objectAtIndex:i];
+                NSMutableArray *myArray = [NSMutableArray array];
+                if ([testTimes objectForKey:test]) {
+                    splitExecTime += [testTimes[test] doubleValue];
+                    [myArray addObject:[NSNumber numberWithDouble:[testTimes[test] doubleValue]]];
+                }
+                i++;
+                if (splitExecTime > maxBundleTime || i >= [bundleTestsToRun count]) {
+                    // Make a bundle out of current xctFile
+                    BPXCTestFile *bundle = [self makeBundle:xctFile
+                                                  withTests:bundleTestsToRun
+                                                    startAt:packed
+                                                   numTests:(i-packed)
+                                              estimatedTime:[NSNumber numberWithDouble:splitExecTime]];
+                    [testBundles addObject:bundle];
+                    packed = i;
+                    sumOfSplits += splitExecTime;
+                    splitExecTime = 0.0;
+                }
+            }
+            [BPUtils printInfo:INFO
+                    withString:@"Bundle execution time is %@ vs sum of splits is %f.", testEstimatedTimesByTestFilePath[xctFile.testBundlePath], sumOfSplits];
+        } else {
+            // just pack the whole xctest file and move on
+            // testsToRun doesn't work reliably, switch to use testsToSkip
+            // add testsToSkip from Bluepill runner's config
+            BPXCTestFile *bundle = [self makeBundle:xctFile withTests:bundleTestsToRun startAt:0 numTests:[bundleTestsToRun count] estimatedTime:testEstimatedTimesByTestFilePath[xctFile.testBundlePath]];
+            [testBundles addObject:bundle];
+        }
+    }
+    [BPUtils printInfo:INFO withString:@"Splitted %lu bundles into %lu bundles.", [xcTestFiles count], [testBundles count]] ;
+
     // Sort bundles by execution times from longest to shortest
-    NSMutableArray *sortedBundles = [NSMutableArray arrayWithArray:[bundles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
+    NSMutableArray *sortedBundles = [NSMutableArray arrayWithArray:[testBundles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
         NSNumber *estimatedTime1 = [(BPXCTestFile *)obj1 estimatedExecutionTime];
         NSNumber *estimatedTime2 = [(BPXCTestFile *)obj2 estimatedExecutionTime];
         if ([estimatedTime1 doubleValue] < [estimatedTime2 doubleValue]) {
@@ -164,10 +218,30 @@
     }]];
     NSNumberFormatter *fmt = [[NSNumberFormatter alloc] init];
     [fmt setPositiveFormat:@".02"];
+    int bpNum = 0;
     for (BPXCTestFile *bundle in sortedBundles) {
-        [BPUtils printInfo:INFO withString:@"Estimated time is %@ for %@", [fmt stringFromNumber:bundle.estimatedExecutionTime], bundle.testBundlePath];
+        [BPUtils printInfo:INFO withString:@"[BP-%d] %@ estimated to take %@ seconds and skips %lu out of %lu tests.", ++bpNum, bundle.name, [fmt stringFromNumber:bundle.estimatedExecutionTime], (unsigned long)[bundle.skipTestIdentifiers count], (unsigned long)[bundle.allTestCases count]];
     }
     return sortedBundles;
+}
+
++ (BPXCTestFile *)makeBundle:(BPXCTestFile *)xctFile
+                   withTests:(NSArray *)bundleTestsToRun
+                     startAt:(NSUInteger)location
+                    numTests:(NSUInteger)length
+               estimatedTime:(NSNumber *)splitExecutionTime {
+    NSMutableArray *testsToSkip = [NSMutableArray arrayWithArray:bundleTestsToRun];
+    NSRange range = NSMakeRange(location, length);
+    [BPUtils printInfo:INFO withString:@"%@: Including range: (%lu, %lu); Tests: %@", xctFile.testBundlePath, (unsigned long)range.location, (unsigned long)range.length, [bundleTestsToRun subarrayWithRange:range]];
+    [testsToSkip removeObjectsInArray:[bundleTestsToRun subarrayWithRange:range]];
+    [testsToSkip addObjectsFromArray:xctFile.skipTestIdentifiers];
+    [testsToSkip sortUsingSelector:@selector(compare:)];
+
+    BPXCTestFile *bundle = [xctFile copy];
+    [bundle setSkipTestIdentifiers:testsToSkip];
+    [bundle setEstimatedExecutionTime:splitExecutionTime];
+
+    return bundle;
 }
 
 @end

--- a/Bluepill-runner/Bluepill-runner/BPRunner.m
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.m
@@ -122,6 +122,7 @@ maxprocs(void)
                            stringByAppendingPathComponent:
                            [NSString stringWithFormat:@"BP-%lu", (unsigned long)number]];
     cfg.testTimeEstimatesJsonFile = self.config.testTimeEstimatesJsonFile;
+    cfg.inheritedClassMappingJsonFile = self.config.inheritedClassMappingJsonFile;
     [cfg printConfig];
     NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:self.bpExecutable];

--- a/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
@@ -85,6 +85,34 @@
     }
 }
 
+- (void)testLoadInheritedClassMapping {
+    self.config.inheritedClassesJsonFile = [BPTestHelper sampleInheritedClassesJsonPath];
+    self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
+    self.config.testCasesToSkip = @[@"BPSampleAppTests/testCase000"];
+    self.config.numSims = @8;
+    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
+    NSArray<BPXCTestFile *> *bundles;
+    NSError *error;
+    bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:&error];
+    XCTAssert(error ==  nil);
+    XCTAssert([app.testBundles count] == [bundles count]);
+}
+
+- (void)testMissingInheritedClassMappingJson {
+    self.config.inheritedClassesJsonFile = @"invalid/inherited/file/path.json";
+    self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
+    self.config.testCasesToSkip = @[@"BPSampleAppTests/testCase000"];
+    self.config.numSims = @8;
+    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
+    NSArray<BPXCTestFile *> *bundles;
+    NSError *error;
+    bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:&error];
+    XCTAssert(error !=  nil);
+    XCTAssert([bundles count] == 0);
+}
+
 - (void)testSmartPackIfJsonFound {
     self.config.testTimeEstimatesJsonFile = [BPTestHelper sampleTimesJsonPath];
     self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];

--- a/Source/Shared/BPConfiguration.h
+++ b/Source/Shared/BPConfiguration.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSArray *allTestCases;
 @property (nonatomic, strong) NSString *configOutputFile;
 @property (nonatomic, strong) NSString *outputDirectory;
+@property (nonatomic, strong) NSString *inheritedClassMappingJsonFile;
 @property (nonatomic, strong) NSString *testTimeEstimatesJsonFile;
 @property (nonatomic, strong) NSString *screenshotsDirectory;
 @property (nonatomic, strong) NSString *simulatorPreferencesFile;

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -78,7 +78,9 @@ struct BPOptions {
     {'o', "output-dir", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "outputDirectory",
         "Directory where to put output log files (bluepill only)."},
     {'j', "test-time-estimates-json", BP_MASTER, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testTimeEstimatesJsonFile",
-        "Directory where Bluepill looks for input files with test execution time estimates (bluepill only)."},
+        "Path of the input file with test execution time estimates (bluepill only)."},
+    {'e', "inherited-class-mapping-json", BP_MASTER, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "inheritedClassMappingJsonFile",
+        "Path of the input file with mapping between base test classes and corresponding inherited test classes."},
     {'r', "runtime", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
         "What runtime to use."},
     {'x', "exclude", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
@@ -698,7 +700,19 @@ static NSUUID *sessionID;
             return NO;
         }
     }
-
+    
+    if (self.inheritedClassMappingJsonFile) {
+        if ([[NSFileManager defaultManager] fileExistsAtPath:self.inheritedClassMappingJsonFile isDirectory:&isdir]) {
+            if (isdir) {
+                BP_SET_ERROR(errPtr, @"%@ is a directory.", self.inheritedClassMappingJsonFile);
+                return NO;
+            }
+        } else {
+            BP_SET_ERROR(errPtr, @"%@ doesn't exist", self.inheritedClassMappingJsonFile);
+            return NO;
+        }
+    }
+    
     if (self.screenshotsDirectory) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:self.screenshotsDirectory isDirectory:&isdir]) {
             if (!isdir) {

--- a/Source/Shared/BPTestClass.h
+++ b/Source/Shared/BPTestClass.h
@@ -10,9 +10,9 @@
 #import <Foundation/Foundation.h>
 #import "BPTestCase.h"
 
-@interface BPTestClass : NSObject
+@interface BPTestClass : NSObject <NSCopying>
 
-@property (nonatomic) NSString *name;
+@property (nonatomic, retain) NSString *name;
 @property (nonatomic) NSMutableArray *testCases;
 
 - (instancetype)initWithName: (NSString *)name;
@@ -21,4 +21,5 @@
 - (NSString *)description;
 - (NSString *)debugDescription;
 - (void)listTestCases;
+- (id) copyWithZone: (NSZone *) zone;
 @end

--- a/Source/Shared/BPTestClass.m
+++ b/Source/Shared/BPTestClass.m
@@ -10,6 +10,7 @@
 #import "BPTestClass.h"
 
 @implementation BPTestClass
+@synthesize name;
 
 -(instancetype)init {
     return [self initWithName:nil];
@@ -46,6 +47,14 @@
 {
     NSString *testcases = [self.testCases componentsJoinedByString:@","];
     return [NSString stringWithFormat:@"<%@: %p> %@ - %lu - %@", [self class], self, self.name, self.testCases.count, testcases];
+}
+
+-(id)copyWithZone:(NSZone *)zone
+{
+    BPTestClass *newObj = [[BPTestClass allocWithZone:zone] init];
+    newObj.name = self.name;
+    newObj.testCases = [self.testCases copy];
+    return newObj;
 }
 
 @end

--- a/Source/Shared/BPUtils.h
+++ b/Source/Shared/BPUtils.h
@@ -146,4 +146,13 @@ typedef BOOL (^BPRunBlock)(void);
  * @return trimmed test name
  */
 + (NSString *)trimTrailingParanthesesFromTestName:(NSString *)testName;
+
+/*!
+ * @discussion loads json mapping file from given absolute path
+ * @param filePath the absolute path of the input json mapping file
+ * @param errPtr an error if loading json mapping fails for some reason
+ * @return a dictionary with the mappings
+ */
++ (NSDictionary *)loadJsonMappingFile:(NSString *)filePath withError:(NSError **)errPtr;
+
 @end

--- a/Source/Shared/BPUtils.m
+++ b/Source/Shared/BPUtils.m
@@ -287,4 +287,16 @@ static BOOL quiet = NO;
     return [testName substringWithRange:regexMatches.firstObject.range];
 }
 
++ (NSDictionary *)loadJsonMappingFile:(NSString *)filePath
+                            withError:(NSError **)errPtr {
+    NSData *data = [NSData dataWithContentsOfFile:filePath
+                                          options:NSDataReadingMappedIfSafe
+                                            error:errPtr];
+    if (!data) return nil;
+
+    return [NSJSONSerialization JSONObjectWithData:data
+                                           options:kNilOptions
+                                             error:errPtr];
+}
+
 @end

--- a/Source/Shared/BPXCTestFile.h
+++ b/Source/Shared/BPXCTestFile.h
@@ -26,16 +26,14 @@
 
 + (instancetype)BPXCTestFileFromXCTestBundle:(NSString *)testBundlePath
                             andHostAppBundle:(NSString *)testHostPath
-                                   withError:(NSError **)errPtr;
-
-+ (instancetype)BPXCTestFileFromXCTestBundle:(NSString *)testBundlePath
-                            andHostAppBundle:(NSString *)testHostPath
                           andUITargetAppPath:(NSString *)UITargetAppPath
+                            andClassMappings:(NSDictionary *)classMappings
                                    withError:(NSError **)errPtr;
 
-+ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*) dict
++ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*)dict
                               withTestRoot:(NSString *)testRoot
                               andXcodePath:(NSString *)xcodePath
+                          andClassMappings:(NSDictionary *)classMappings
                                   andError:(NSError **)errPtr;
 
 - (NSUInteger)numTests;

--- a/Source/Shared/BPXCTestFile.m
+++ b/Source/Shared/BPXCTestFile.m
@@ -17,18 +17,10 @@
 NSString *swiftNmCmdline = @"nm -gU '%@' | cut -d' ' -f3 | xargs -s 131072 xcrun swift-demangle | cut -d' ' -f3 | grep -e '[\\.|_]'test";
 NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-' -f2 | cut -d'[' -f2 | cut -d']' -f1 | grep ' test'";
 
-+ (instancetype)BPXCTestFileFromXCTestBundle:(NSString *)testBundlePath
-                            andHostAppBundle:(NSString *)testHostPath
-                                   withError:(NSError *__autoreleasing *)errPtr {
-    return [BPXCTestFile BPXCTestFileFromXCTestBundle:testBundlePath
-                                     andHostAppBundle:testHostPath
-                                   andUITargetAppPath:nil
-                                            withError:errPtr];
-}
-
 + (instancetype)BPXCTestFileFromXCTestBundle:(NSString *)path
                             andHostAppBundle:(NSString *)testHostPath
                           andUITargetAppPath:(NSString *)UITargetAppPath
+                            andClassMappings:(NSDictionary *)classMappings
                                    withError:(NSError **)errPtr {
     BOOL isDir = NO;
 
@@ -97,8 +89,23 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
         }
         [testClass addTestCase:[[BPTestCase alloc] initWithName:parts[1]]];
     }
-
-
+    if (classMappings) {
+        NSMutableArray *newClasses = [[NSMutableArray alloc] init];
+        for (id key in allClasses) {
+            BPTestClass *testClass = (BPTestClass *)key;
+            if ([classMappings objectForKey:[testClass name]]) {
+                NSArray<NSString *> *derivedClassNames = [(NSString *)[classMappings objectForKey:[testClass name]] componentsSeparatedByString:@","];
+                [BPUtils printInfo:INFO withString:@"In Mapping: Base Class Name = %@; testCase count: %lu; Derived Class Names: %@", [testClass name], (unsigned long)[testClass numTests], derivedClassNames];
+                for (NSString *derivedClassName in derivedClassNames) {
+                    BPTestClass *bpTestClass = [testClass copy];
+                    [bpTestClass setName:derivedClassName];
+                    testClassesDict[derivedClassName] = bpTestClass;
+                    [newClasses addObject:bpTestClass];
+                }
+            }
+        }
+        [allClasses addObjectsFromArray:newClasses];
+    }
     xcTestFile.testClasses = [NSArray arrayWithArray:allClasses];
     return xcTestFile;
 }
@@ -106,6 +113,7 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
 + (instancetype)BPXCTestFileFromDictionary:(NSDictionary *)dict
                               withTestRoot:(NSString *)testRoot
                               andXcodePath:(NSString *)xcodePath
+                          andClassMappings:(NSDictionary *)classMappings
                                   andError:(NSError *__autoreleasing *)errPtr {
     NSAssert(dict, @"A dictionary should be provided");
     NSAssert(testRoot, @"A testRoot argument must be supplied");
@@ -143,6 +151,7 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
     BPXCTestFile *xcTestFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:testBundlePath
                                                          andHostAppBundle:testHostPath
                                                        andUITargetAppPath:UITargetAppPath
+                                                         andClassMappings:classMappings
                                                                 withError:errPtr];
     if (!xcTestFile) {
         return nil;


### PR DESCRIPTION
This PR fixes the issue https://github.com/linkedin/bluepill/issues/352 and introduces smart splitting of test bundles based on test execution time estimates.
@ob, Please review.