### PR TITLE
Use lightweight tags in git describe

### DIFF
--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -58,7 +58,7 @@ bluepill_build()
   }
   set +o pipefail
   # package bluepill
-  TAG=$(git describe --always)
+  TAG=$(git describe --always --tags)
   DST="Bluepill-$TAG"
   mkdir -p build/$DST/bin
   cp build/Build/Products/Release/{bp,bluepill} build/$DST/bin

--- a/scripts/bpversion.sh
+++ b/scripts/bpversion.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 OUT_FILE=$1
 REPO_ROOT=$(git rev-parse --show-toplevel)
-VERSION=$(git describe --always)
+VERSION=$(git describe --always --tags)
 test -z "$VERSION" && VERSION=$(cat "$REPO_ROOT/VERSION")
 echo "#define BP_VERSION \"$VERSION\"" > "$OUT_FILE"
 XCODE_VERSION=$(xcodebuild -version | awk 'BEGIN {OFS="";} /Xcode/ {version=$2} /Build version/ {build=$3} END {print version, " (", build, ")";}')


### PR DESCRIPTION
GitHub actions doesn't seem to trigger releases on annotated tags, so add the --tags flag to the calls to git describe so that it honors lightweight tags.