### PR TITLE
Use code injection to get the actual list of tests instead of running nm on the xctest bundle

### DIFF
--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.h
@@ -8,10 +8,21 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "BPXCTestFile.h"
 #import "SimDevice.h"
+
 @class BPConfiguration;
 
 @interface SimulatorHelper : NSObject
+
+/*!
+ * @discussion creates the template simulators one for each type of app bundle used by input xctest files
+ * @param xcTestFiles XCTest files with info on the test hosts to be installed.
+ * @param config the configuration object
+ * @return a dictionary with key to be the host bundle path and value to be the template simulator
+ */
++ (NSDictionary *)createSimTemplatesAndDumpTests:(NSArray<BPXCTestFile *>*)xcTestFiles
+                                      withConfig:(BPConfiguration *)config;
 
 /*!
  * @discussion load the required frameworks

--- a/Bluepill-runner/Bluepill-runner/BPRunner.h
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.h
@@ -25,6 +25,7 @@
  * @return return the BPRunner to start running tests
  */
 + (instancetype)BPRunnerWithConfig:(BPConfiguration *)config
+          withTestHostSimTemplates:(NSDictionary *)testHostSimTemplates
                         withBpPath:(NSString *)bpPath;
 
 /*!

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -11,6 +11,7 @@
 #import <BluepillLib/BPStats.h>
 #import <BluepillLib/BPUtils.h>
 #import <BluepillLib/BPWriter.h>
+#import <BluepillLib/SimulatorHelper.h>
 #import <Foundation/Foundation.h>
 #import <getopt.h>
 #import <libgen.h>
@@ -97,16 +98,20 @@ int main(int argc, char * argv[]) {
             exit(1);
         }
         [[BPStats sharedStats] endTimer:@"Loading App" withResult:@"INFO"];
+        // Always create simulator template(s)
+        // TODO: Deprecate clone-simulator flag
+        NSDictionary *testHostSimTemplates = [SimulatorHelper createSimTemplatesAndDumpTests:app.testBundles withConfig:config];
         if (config.listTestsOnly) {
             [app listTests];
             exit(0);
         }
-
         [[BPStats sharedStats] startTimer:@"Normalizing Configuration"];
         BPConfiguration *normalizedConfig = [BPUtils normalizeConfiguration:config withTestFiles:app.testBundles];
         [[BPStats sharedStats] endTimer:@"Normalizing Configuration" withResult:@"INFO"];
         // start a runner and let it fly
-        BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig withBpPath:nil];
+        BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig
+                               withTestHostSimTemplates:testHostSimTemplates
+                                             withBpPath:nil];
         if (!runner) {
             fprintf(stderr, "ERROR: Unable to create Bluepill Runner.\n");
             exit(1);

--- a/Bluepill-runner/Bluepill.xcodeproj/xcshareddata/xcschemes/bp_test_dumper.xcscheme
+++ b/Bluepill-runner/Bluepill.xcodeproj/xcshareddata/xcschemes/bp_test_dumper.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4B88E8A2361235B003A8DCB"
+               BuildableName = "bp_test_dumper.dylib"
+               BlueprintName = "bp_test_dumper"
+               ReferencedContainer = "container:bluepill.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B88E8A2361235B003A8DCB"
+            BuildableName = "bp_test_dumper.dylib"
+            BlueprintName = "bp_test_dumper"
+            ReferencedContainer = "container:bluepill.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B88E8A2361235B003A8DCB"
+            BuildableName = "bp_test_dumper.dylib"
+            BlueprintName = "bp_test_dumper"
+            ReferencedContainer = "container:bluepill.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Bluepill-runner/BluepillRunnerTests/BPAppTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPAppTests.m
@@ -57,6 +57,7 @@
     XCTAssert(app.testBundles.count == 1);
     BPXCTestFile *testBundle = app.testBundles[0];
     XCTAssertEqualObjects(testBundle.testBundlePath, self.config.testBundlePath);
+    XCTAssert([testBundle.allTestCases count] == 8);
 }
 
 @end

--- a/Bluepill-runner/bluepill.xcodeproj/project.pbxproj
+++ b/Bluepill-runner/bluepill.xcodeproj/project.pbxproj
@@ -33,7 +33,20 @@
 		C4C614A421814C5C008A2C39 /* BPTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C4C614A321814C5C008A2C39 /* BPTestHelper.m */; };
 		C4FD8C581DB6E09B000ED28C /* BPPacker.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FD8C571DB6E09B000ED28C /* BPPacker.m */; };
 		E49235FF22EA847700395D98 /* times.json in Resources */ = {isa = PBXBuildFile; fileRef = E49235FE22EA847700395D98 /* times.json */; };
+		E4B88E952361242F003A8DCB /* bp_test_dumper.m in Sources */ = {isa = PBXBuildFile; fileRef = E4B88E942361242F003A8DCB /* bp_test_dumper.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E4B88E892361235B003A8DCB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		56B74BC91E4C0A15004E6624 /* BPIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPIntegrationTests.m; sourceTree = "<group>"; };
@@ -68,6 +81,8 @@
 		C4FD8C561DB6E09B000ED28C /* BPPacker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPPacker.h; sourceTree = "<group>"; };
 		C4FD8C571DB6E09B000ED28C /* BPPacker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPPacker.m; sourceTree = "<group>"; };
 		E49235FE22EA847700395D98 /* times.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = times.json; sourceTree = "<group>"; };
+		E4B88E8B2361235B003A8DCB /* bp_test_dumper.dylib */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = bp_test_dumper.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4B88E942361242F003A8DCB /* bp_test_dumper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = bp_test_dumper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +100,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA9ADEAA216427CB001306F5 /* BluepillLib.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4B88E882361235B003A8DCB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +192,7 @@
 				BAFCCA361E33595F00E33C31 /* bluepill.xcconfig */,
 				BAEF4B361DAC539400E68294 /* Bluepill */,
 				BA1809E11DBA8FB100D7D130 /* BluepillRunnerTests */,
+				E4B88E8C2361235B003A8DCB /* bp_test_dumper */,
 				BAEF4B351DAC539400E68294 /* Products */,
 				B3380AED2150BD8600752E1B /* Frameworks */,
 			);
@@ -180,6 +203,7 @@
 			children = (
 				BAEF4B341DAC539400E68294 /* bluepill */,
 				BA1809E01DBA8FB100D7D130 /* BluepillRunnerTests.xctest */,
+				E4B88E8B2361235B003A8DCB /* bp_test_dumper.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -208,6 +232,14 @@
 				C49EEB83225570EC002CC956 /* result4.xml */,
 			);
 			path = 4;
+			sourceTree = "<group>";
+		};
+		E4B88E8C2361235B003A8DCB /* bp_test_dumper */ = {
+			isa = PBXGroup;
+			children = (
+				E4B88E942361242F003A8DCB /* bp_test_dumper.m */,
+			);
+			path = bp_test_dumper;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -247,6 +279,23 @@
 			productReference = BAEF4B341DAC539400E68294 /* bluepill */;
 			productType = "com.apple.product-type.tool";
 		};
+		E4B88E8A2361235B003A8DCB /* bp_test_dumper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4B88E932361235B003A8DCB /* Build configuration list for PBXNativeTarget "bp_test_dumper" */;
+			buildPhases = (
+				E4B88E872361235B003A8DCB /* Sources */,
+				E4B88E882361235B003A8DCB /* Frameworks */,
+				E4B88E892361235B003A8DCB /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = bp_test_dumper;
+			productName = bp_test_dumper;
+			productReference = E4B88E8B2361235B003A8DCB /* bp_test_dumper.dylib */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -263,6 +312,11 @@
 					};
 					BAEF4B331DAC539400E68294 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = 57Y47U492U;
+						ProvisioningStyle = Automatic;
+					};
+					E4B88E8A2361235B003A8DCB = {
+						CreatedOnToolsVersion = 10.2.1;
 						DevelopmentTeam = 57Y47U492U;
 						ProvisioningStyle = Automatic;
 					};
@@ -283,6 +337,7 @@
 			targets = (
 				BAEF4B331DAC539400E68294 /* bluepill */,
 				BA1809DF1DBA8FB100D7D130 /* BluepillRunnerTests */,
+				E4B88E8A2361235B003A8DCB /* bp_test_dumper */,
 			);
 		};
 /* End PBXProject section */
@@ -350,6 +405,14 @@
 				C41C41F91DB14B5F001F32A2 /* BPRunner.m in Sources */,
 				BAD8484A1DBC6A83007034CF /* BPReportCollector.m in Sources */,
 				C41C41F31DB04032001F32A2 /* BPApp.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4B88E872361235B003A8DCB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4B88E952361242F003A8DCB /* bp_test_dumper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -500,7 +563,18 @@
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPER_PRIVATE_FRAMEWORKS_DIR = "";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\"/Library/Developer/PrivateFrameworks\"",
+					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"",
+					"\"$(DEVELOPER_DIR)/../SharedFrameworks\"",
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					CoreSimulator,
@@ -518,6 +592,16 @@
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPER_PRIVATE_FRAMEWORKS_DIR = "";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\"/Library/Developer/PrivateFrameworks\"",
+					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"",
+					"\"$(DEVELOPER_DIR)/../SharedFrameworks\"",
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
@@ -527,6 +611,100 @@
 				);
 				PRIVATE_FRAMEWORKS_DIR = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E4B88E912361235B003A8DCB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)";
+				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)";
+				DEVELOPMENT_TEAM = 57Y47U492U;
+				ENABLE_BITCODE = NO;
+				EXECUTABLE_EXTENSION = dylib;
+				EXECUTABLE_PREFIX = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\"/Library/Developer/PrivateFrameworks\"",
+					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"",
+					"\"$(DEVELOPER_DIR)/../SharedFrameworks\"",
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-weak_framework",
+					CoreSimulator,
+					"-weak_framework",
+					XCTest,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = NO;
+			};
+			name = Debug;
+		};
+		E4B88E922361235B003A8DCB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)";
+				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(CONFIGURATION)";
+				DEVELOPMENT_TEAM = 57Y47U492U;
+				ENABLE_BITCODE = NO;
+				EXECUTABLE_EXTENSION = dylib;
+				EXECUTABLE_PREFIX = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\"/Library/Developer/PrivateFrameworks\"",
+					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)\"",
+					"\"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"",
+					"\"$(DEVELOPER_DIR)/../SharedFrameworks\"",
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-weak_framework",
+					CoreSimulator,
+					"-weak_framework",
+					XCTest,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = NO;
 			};
 			name = Release;
 		};
@@ -556,6 +734,15 @@
 			buildConfigurations = (
 				BAEF4B3C1DAC539400E68294 /* Debug */,
 				BAEF4B3D1DAC539400E68294 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E4B88E932361235B003A8DCB /* Build configuration list for PBXNativeTarget "bp_test_dumper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4B88E912361235B003A8DCB /* Debug */,
+				E4B88E922361235B003A8DCB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Bluepill-runner/bp_test_dumper/bp_test_dumper.m
+++ b/Bluepill-runner/bp_test_dumper/bp_test_dumper.m
@@ -1,0 +1,94 @@
+//
+//  bp_test_dumper.m
+//  bp_test_dumper
+//
+//  Created by Ravi K. Mandala on 10/23/19.
+//  Copyright © 2019 LinkedIn. All rights reserved.
+//
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#define OUTPUT_FILE_PATH "_BP_TEST_LIST_FILE"
+
+NSString *getSimpleName(NSString *testName) {
+    // Extracting test name from a string like "-[FeedHighlightedUpdateTrackingTest testFeedHighlightedUpdateEvent]"
+    NSString *simpleTestName = [testName componentsSeparatedByString:@" "][1];
+    simpleTestName = [simpleTestName substringToIndex:simpleTestName.length-1];
+    return simpleTestName;
+}
+
+/* Return code:
+ * 0 - Successful
+ * 1 - Error loading the test bundles
+ * 2 - Error writing output file
+ */
+__attribute__((constructor))
+void read_it() {
+    NSString *outputFilePath = [[NSProcessInfo processInfo] environment][@OUTPUT_FILE_PATH];
+    if (!outputFilePath) {
+        NSLog(@"[BPTestDumper] Environment variable for Output file path not set. Please set %@ and try again.", @OUTPUT_FILE_PATH);
+        exit(2);
+    }
+    NSLog(@"[BPTestDumper] Output test dump file path is %@", outputFilePath);
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    NSString *pluginsPath = [mainBundle builtInPlugInsPath];
+    NSArray *xcTests = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:pluginsPath error:Nil];
+    NSLog(@"[BPTestDumper] Got a total of %lu xctest bundles.", [xcTests count]);
+    for (NSString *xcTestBundlePath in xcTests) {
+        NSString *ext = [xcTestBundlePath pathExtension];
+        if (![ext isEqual:@"xctest"]) {
+            NSLog(@"[BPTestDumper] Skipping %@ - %@", xcTestBundlePath, ext);
+            continue;
+        }
+        NSString *path = [pluginsPath stringByAppendingPathComponent:xcTestBundlePath];
+        NSLog(@"[BPTestDumper] Loading %@", path);
+        NSBundle *bundle = [NSBundle bundleWithPath:path];
+        if (!bundle) {
+            NSLog(@"[BPTestDumper] bundle failed to load!");
+            perror("bundle");
+            exit(1);
+        }
+        [bundle load];
+    }
+    NSLog(@"[BPTestDumper] Creating a default test suite with all suites of suites...");
+    XCTestSuite *defaultTestSuite = [XCTestSuite defaultTestSuite];
+    if (!defaultTestSuite) {
+        NSLog(@"[BPTestDumper] Failed to create a defaultTestSuite");
+        exit(1);
+    }
+    NSLog(@"[BPTestDumper] Successfully created a defaultTestSuite!");
+    NSMutableDictionary *testInfoDict = [[NSMutableDictionary alloc] init];
+    for (XCTestSuite *testSuite in [defaultTestSuite tests]) {
+        NSLog(@"[BPTestDumper] Parsing test bundle - %@; Number of test classes = %lu", [testSuite name], [testSuite testCaseCount]);
+        NSMutableDictionary *testClassesDict = [[NSMutableDictionary alloc] init];
+        for (XCTestSuite *testClass in [testSuite tests]) {
+            NSMutableArray *testCaseList = [[NSMutableArray alloc] init];
+            NSLog(@"[BPTestDumper] Parsing test class - %@; Number of test cases = %lu", [testClass name], [testClass testCaseCount]);
+            for (XCTest *testCase in [testClass tests]) {
+                NSLog(@"[BPTestDumper] Test case: %@", getSimpleName([testCase name]));
+                [testCaseList addObject:getSimpleName([testCase name])];
+            }
+            if ([testCaseList count] > 0) {
+                [testClassesDict setObject:(NSArray *)testCaseList forKey:[testClass name]];
+            }
+        }
+        if ([testClassesDict count] > 0) {
+            [testInfoDict setValue:testClassesDict forKey:[testSuite name]];
+        }
+    }
+    NSError *err;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:testInfoDict
+                                                   options:NSJSONWritingPrettyPrinted
+                                                     error:&err];
+    if (!json) {
+        NSLog(@"[BPTestDumper] ERROR: %@", [err localizedDescription]);
+        exit(2);
+    }
+    if (![json writeToFile:outputFilePath atomically:YES]) {
+        NSLog(@"[BPTestDumper] Failed to dump the test list");
+        exit(2);
+    }
+    NSLog(@"[BPTestDumper] Successfully dumped a list of tests into the output file: %@", outputFilePath);
+    // don't actually run the app
+    exit(0);
+}

--- a/Source/Shared/BPConstants.h
+++ b/Source/Shared/BPConstants.h
@@ -14,6 +14,7 @@
 #define BP_DEFAULT_RUNTIME "iOS 12.2"
 #define BP_DEFAULT_XCODE_VERSION "10.2"
 #define BP_MAX_PROCESSES_PERCENT 0.75
+#define BP_TEST_DUMPER_NAME "bp_test_dumper.dylib"
 #define BP_TM_PROTOCOL_VERSION 17
 
 


### PR DESCRIPTION
Bluepill gets the list of tests using `nm` util which fails to capture inherited and generated test methods, as mentioned in the issue https://github.com/linkedin/bluepill/issues/352. Due to this inaccuracy when bundles are split there could be duplicate execution of the same test in multiple bundles.
In this fix, the clone simulator option is made the default behavior and a test dumper is injected into the simulator clones as a dynamic library which effectively dumps an accurate list of tests upon app launch. The dumped list of tests will be used it accurately forming a runtime test configuration and achieve precision in splitting at a later stage.
@ob @jmkk @vaibhav-shah @nanwng