### PR TITLE
Fail if bp binary is not found adjacent to bluepill and also some refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+Bluepill.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist

--- a/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
+++ b/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
@@ -198,16 +198,6 @@
                ReferencedContainer = "container:BPSampleApp.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C40B277022492E5200FAAF67"
-               BuildableName = "BPSampleAppTestsBugs.xctest"
-               BlueprintName = "BPSampleAppTestsBugs"
-               ReferencedContainer = "container:BPSampleApp.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
+++ b/Bluepill-cli/Bluepill-cli/Bluepill/Bluepill.m
@@ -206,9 +206,8 @@ void onInterrupt(int ignore) {
     BPXCTestFile *xctTestFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:context.config.testBundlePath
                                                           andHostAppBundle:testHostPath
                                                                  withError:&error];
-    NSAssert(xctTestFile != nil, @"Failed to load testcases from %@", [error localizedDescription]);
+    NSAssert(xctTestFile != nil, @"Failed to load testcases from: %@; Error: %@", context.config.testBundlePath, [error localizedDescription]);
     context.config.allTestCases = [[NSArray alloc] initWithArray: xctTestFile.allTestCases];
-
 
     context.attemptNumber = self.retries + 1;
     self.context = context; // Store the context on self so that it's accessible to the interrupt handler in the loop
@@ -227,10 +226,9 @@ void onInterrupt(int ignore) {
         NSError *err;
         NSString *tmpFileName = [BPUtils mkstemp:[NSString stringWithFormat:@"%@/%lu-bp-stdout-%u", NSTemporaryDirectory(), context.attemptNumber, getpid()]
                                        withError:&err];
-        simulatorLogPath = tmpFileName;
-        if (!tmpFileName) {
-            simulatorLogPath = [NSString stringWithFormat:@"/tmp/%lu-simulator.log", context.attemptNumber];
-            [BPUtils printInfo:ERROR withString:@"ERROR: %@\nLeaving log in %@", [err localizedDescription], simulatorLogPath];
+        simulatorLogPath = tmpFileName? tmpFileName : [NSString stringWithFormat:@"/tmp/%lu-simulator.log", context.attemptNumber];
+        if (err) {
+            [BPUtils printInfo:ERROR withString:@"Error: %@\nLeaving log in %@", [err localizedDescription], simulatorLogPath];
         }
     }
 

--- a/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.h
+++ b/Bluepill-cli/Bluepill-cli/Simulator/SimulatorHelper.h
@@ -33,6 +33,7 @@
 
 /*!
  * @discussion get the path of the environment configuration file
+ * @param config the configuration object
  * @return return the path to the test configuration file.
  */
 + (NSString *)testEnvironmentWithConfiguration:(BPConfiguration *)config;

--- a/Bluepill-runner/Bluepill-runner/BPApp.m
+++ b/Bluepill-runner/Bluepill-runner/BPApp.m
@@ -68,7 +68,7 @@
                                        andXcodePath:(NSString *)xcodePath
                                           withError:(NSError *__autoreleasing *)errPtr {
 
-    NSMutableArray<BPXCTestFile *> *allTests = [[NSMutableArray alloc] init];
+    NSMutableArray<BPXCTestFile *> *allXCTestFiles = [[NSMutableArray alloc] init];
     NSUInteger errorCount = 0;
     for (NSString *key in xcTestRunDict) {
         if ([key isEqualToString:@"__xctestrun_metadata__"]) {
@@ -84,40 +84,39 @@
             errorCount++;
             continue;
         }
-        [allTests addObject:xcTestFile];
+        [allXCTestFiles addObject:xcTestFile];
     }
     if (errorCount) {
         BP_SET_ERROR(errPtr, @"Failed to load some test bundles");
         return nil;
     }
-    return allTests;
+    return allXCTestFiles;
 }
 
 + (instancetype)appWithConfig:(BPConfiguration *)config
                     withError:(NSError *__autoreleasing *)errPtr {
 
     BPApp *app = [[BPApp alloc] init];
-    NSMutableArray<BPXCTestFile *> *allTests = [[NSMutableArray alloc] init];
-
+    NSMutableArray<BPXCTestFile *> *allXCTestFiles = [[NSMutableArray alloc] init];
     if (config.xcTestRunDict) {
         NSAssert(config.xcTestRunPath, @"");
         [BPUtils printInfo:INFO withString:@"Using xctestrun configuration"];
         NSArray<BPXCTestFile *> *loadedTests = [BPApp testsFromXCTestRunDict:config.xcTestRunDict
-                                                           andXCTestRunPath:config.xcTestRunPath
+                                                            andXCTestRunPath:config.xcTestRunPath
                                                                 andXcodePath:config.xcodePath
                                                                    withError:errPtr];
         if (loadedTests == nil) {
             return nil;
         }
 
-        [allTests addObjectsFromArray:loadedTests];
+        [allXCTestFiles addObjectsFromArray:loadedTests];
     } else if (config.appBundlePath) {
         NSAssert(config.appBundlePath, @"no app bundle and no xctestrun file");
         [BPUtils printInfo:WARNING withString:@"Using broken configuration, consider using .xctestrun files"];
-        [allTests addObjectsFromArray:[BPApp testsFromAppBundle:config.appBundlePath
-                                              andTestBundlePath:config.testBundlePath
-                                             andUITargetAppPath:config.testRunnerAppPath
-                                                      withError:errPtr]];
+        [allXCTestFiles addObjectsFromArray:[BPApp testsFromAppBundle:config.appBundlePath
+                                                    andTestBundlePath:config.testBundlePath
+                                                   andUITargetAppPath:config.testRunnerAppPath
+                                                            withError:errPtr]];
     } else {
         BP_SET_ERROR(errPtr, @"xctestrun file must be given, see usage.");
         return nil;
@@ -128,8 +127,8 @@
             BPXCTestFile *testFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:testBundle
                                                                andHostAppBundle:config.appBundlePath
                                                              andUITargetAppPath:config.testRunnerAppPath
-                                                                    withError:errPtr];
-            [allTests addObject:testFile];
+                                                                      withError:errPtr];
+            [allXCTestFiles addObject:testFile];
         }
     }
 
@@ -137,12 +136,12 @@
         for (NSString *testBundle in config.additionalUnitTestBundles) {
             BPXCTestFile *testFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:testBundle
                                                                andHostAppBundle:config.testRunnerAppPath
-                                                                    withError:errPtr];
-            [allTests addObject:testFile];
+                                                                      withError:errPtr];
+            [allXCTestFiles addObject:testFile];
         }
     }
 
-    app.testBundles = allTests;
+    app.testBundles = allXCTestFiles;
     return app;
 }
 

--- a/Bluepill-runner/Bluepill-runner/BPPacker.m
+++ b/Bluepill-runner/Bluepill-runner/BPPacker.m
@@ -8,9 +8,9 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <BluepillLib/BPConstants.h>
-#import "BPPacker.h"
-#import <BluepillLib/BPXCTestFile.h>
 #import <BluepillLib/BPUtils.h>
+#import <BluepillLib/BPXCTestFile.h>
+#import "BPPacker.h"
 
 @implementation BPPacker
 
@@ -58,7 +58,7 @@
             }
         }
     }
-    
+
     NSUInteger testsPerGroup = MAX(1, totalTests / numBundles);
     NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
@@ -109,9 +109,12 @@
     }
 
     // load the config file
-    NSDictionary *testTimes = [self loadConfigFile:config.testTimeEstimatesJsonFile withError:errPtr];
-    if ((errPtr && *errPtr) || !testTimes) {
+    NSDictionary *testTimes = [BPUtils loadSimpleJsonFile:config.testTimeEstimatesJsonFile withError:errPtr];
+    if (errPtr && *errPtr) {
         [BPUtils printInfo:ERROR withString:@"%@", [*errPtr localizedDescription]];
+        return NULL;
+    } else if (!testTimes) {
+        [BPUtils printInfo:ERROR withString:@"Invalid test execution time data"];
         return NULL;
     }
 
@@ -170,14 +173,4 @@
     return sortedBundles;
 }
 
-+ (NSDictionary *)loadConfigFile:(NSString *)file withError:(NSError **)errPtr{
-    NSData *data = [NSData dataWithContentsOfFile:file
-                                          options:NSDataReadingMappedIfSafe
-                                            error:errPtr];
-    if (!data) return nil;
-
-    return [NSJSONSerialization JSONObjectWithData:data
-                                           options:kNilOptions
-                                             error:errPtr];
-}
 @end

--- a/Bluepill-runner/Bluepill-runner/BPReportCollector.m
+++ b/Bluepill-runner/Bluepill-runner/BPReportCollector.m
@@ -59,8 +59,7 @@
         NSNumber *isDirectory = nil;
         if (![url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
             [BPUtils printInfo:ERROR withString:@"Failed to get resource from url %@", url];
-        }
-        else if (![isDirectory boolValue]) {
+        } else if (![isDirectory boolValue]) {
             if ([[url pathExtension] isEqualToString:@"xml"]) {
                 [BPUtils printInfo:DEBUGINFO withString:@"JUnit collecting: %@", [url path]];
                 NSString *path = [url path];

--- a/Bluepill-runner/Bluepill-runner/BPRunner.h
+++ b/Bluepill-runner/Bluepill-runner/BPRunner.h
@@ -16,7 +16,7 @@
 @property (nonatomic, strong) BPConfiguration *config;
 @property (nonatomic, strong) NSString *bpExecutable;
 @property (nonatomic, strong) NSMutableArray *nsTaskList;
-@property (nonatomic, strong) NSMutableDictionary* testHostForSimUDID;
+@property (nonatomic, strong) NSDictionary *testHostSimTemplates;
 
 /*!
  * @discussion get a BPRunnner to run tests
@@ -40,11 +40,12 @@
                     andNumber:(NSUInteger)number
                     andDevice:(NSString *)deviceID
            andCompletionBlock:(void (^)(NSTask * ))block;
+
 /**
  @discussion start running tests
  @return 1: test failures 0: pass -1: failed to run tests
  */
 - (int)runWithBPXCTestFiles:(NSArray<BPXCTestFile *>*)xcTestFiles;
-- (void) interrupt;
 
+- (void) interrupt;
 @end

--- a/Bluepill-runner/Bluepill-runner/main.m
+++ b/Bluepill-runner/Bluepill-runner/main.m
@@ -7,17 +7,17 @@
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
-#import <Foundation/Foundation.h>
-#import "BPApp.h"
 #import <BluepillLib/BPConfiguration.h>
-#import "BPRunner.h"
-#import "BPVersion.h"
-#import "BPReportCollector.h"
-#import <BluepillLib/BPUtils.h>
 #import <BluepillLib/BPStats.h>
+#import <BluepillLib/BPUtils.h>
 #import <BluepillLib/BPWriter.h>
+#import <Foundation/Foundation.h>
 #import <getopt.h>
 #import <libgen.h>
+#import "BPApp.h"
+#import "BPReportCollector.h"
+#import "BPRunner.h"
+#import "BPVersion.h"
 
 #include <sys/ioctl.h>
 #include <string.h>
@@ -84,7 +84,7 @@ int main(int argc, char * argv[]) {
 
         NSError *err = nil;
         if (![config processOptionsWithError:&err] || ![config validateConfigWithError:&err]) {
-            fprintf(stderr, "%s: invalid configuration\n\t%s\n",
+            fprintf(stderr, "%s: Invalid configuration\n\t%s\n",
                     basename(argv[0]), [[err localizedDescription] UTF8String]);
             exit(1);
         }
@@ -107,6 +107,10 @@ int main(int argc, char * argv[]) {
         [[BPStats sharedStats] endTimer:@"Normalizing Configuration" withResult:@"INFO"];
         // start a runner and let it fly
         BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig withBpPath:nil];
+        if (!runner) {
+            fprintf(stderr, "ERROR: Unable to create Bluepill Runner.\n");
+            exit(1);
+        }
         int rc = [runner runWithBPXCTestFiles:app.testBundles];
         if (config.outputDirectory) {
             // write the stats

--- a/Bluepill-runner/BluepillRunnerTests/BPAppTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPAppTests.m
@@ -8,12 +8,12 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "BPTestHelper.h"
 #import <BluepillLib/BPConfiguration.h>
-#import "BPApp.h"
 #import <BluepillLib/BPXCTestFile.h>
 #import <BluepillLib/BPUtils.h>
 #import <BluepillLib/BPConstants.h>
+#import "BPApp.h"
+#import "BPTestHelper.h"
 
 @interface BPAppTests : XCTestCase
 @property (nonatomic, strong) BPConfiguration* config;
@@ -23,7 +23,7 @@
 
 - (void)setUp {
     [super setUp];
-    
+
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
     self.config = [BPConfiguration new];
@@ -44,14 +44,15 @@
 - (void)testAppWithAppBundlePathNoError {
     NSError *error;
     self.config.testBundlePath = nil;
-    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    self.config.appBundlePath = [BPTestHelper sampleAppPath];
+    BPApp *app = [BPApp appWithConfig:self.config withError:&error];
     XCTAssertNil(error);
     XCTAssert(app.testBundles.count > 2);
 }
 
 - (void)testAppWithOnlyTestBundlePath {
     NSError *error;
-    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    BPApp *app = [BPApp appWithConfig:self.config withError:&error];
     XCTAssertNil(error);
     XCTAssert(app.testBundles.count == 1);
     BPXCTestFile *testBundle = app.testBundles[0];

--- a/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPIntegrationTests.m
@@ -59,6 +59,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -74,6 +75,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -92,6 +94,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -114,6 +117,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -131,6 +135,7 @@
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 8);
     XCTAssert(rc != 0); // this runs tests that fail
@@ -144,6 +149,7 @@
                             withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);
     XCTAssert([runner.nsTaskList count] == 0);

--- a/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
+++ b/Bluepill-runner/BluepillRunnerTests/BPPackerTests.m
@@ -52,9 +52,9 @@
     self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.numSims = @2;
     BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
     app.testBundles[0].skipTestIdentifiers = @[@"BPSampleAppTests/testCase000", @"BPSampleAppTests/testCase001"];
 
-    XCTAssert(app != nil);
     NSArray<BPXCTestFile *> *bundles;
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];
     for (BPXCTestFile *file in app.testBundles) {
@@ -67,6 +67,7 @@
     self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.numSims = @8;
     BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
     NSMutableArray *testCasesToSkip = [NSMutableArray new];
     for (BPXCTestFile *xctFile in app.testBundles) {
         [testCasesToSkip addObjectsFromArray:xctFile.allTestCases];

--- a/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill-tests.xcscheme
+++ b/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill-tests.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A7901811D5CB679004D4325"
-               BuildableName = "bp"
-               BlueprintName = "bp"
-               ReferencedContainer = "container:../Bluepill-cli/bp.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "BAEF4B331DAC539400E68294"
                BuildableName = "bluepill"
                BlueprintName = "bluepill"
@@ -131,10 +117,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7A7901811D5CB679004D4325"
-            BuildableName = "bp"
-            BlueprintName = "bp"
-            ReferencedContainer = "container:../Bluepill-cli/bp.xcodeproj">
+            BlueprintIdentifier = "BAEF4B331DAC539400E68294"
+            BuildableName = "bluepill"
+            BlueprintName = "bluepill"
+            ReferencedContainer = "container:bluepill.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill.xcscheme
+++ b/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -65,6 +65,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       stopOnEveryUBSanitizerIssue = "YES"
+      migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable

--- a/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill.xcscheme
+++ b/Bluepill-runner/bluepill.xcodeproj/xcshareddata/xcschemes/bluepill.xcscheme
@@ -34,20 +34,6 @@
                ReferencedContainer = "container:bluepill.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7A13E5A91DD22A3A004034BC"
-               BuildableName = "Bluepill-gui.app"
-               BlueprintName = "Bluepill-gui"
-               ReferencedContainer = "container:../Bluepill-gui/Bluepill-gui.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Source/Shared/BPConfiguration.m
+++ b/Source/Shared/BPConfiguration.m
@@ -78,7 +78,7 @@ struct BPOptions {
     {'o', "output-dir", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "outputDirectory",
         "Directory where to put output log files (bluepill only)."},
     {'j', "test-time-estimates-json", BP_MASTER, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testTimeEstimatesJsonFile",
-        "Directory where Bluepill looks for input files with test execution time estimates (bluepill only)."},
+        "Path of the input file with test execution time estimates."},
     {'r', "runtime", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
         "What runtime to use."},
     {'x', "exclude", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
@@ -272,8 +272,7 @@ static NSUUID *sessionID;
                              atomically:NO
                                encoding:NSUTF8StringEncoding
                                   error:&err]) {
-        fprintf(stderr, "Could not write config to file %s\nERROR: %s\n",
-                [self.configOutputFile UTF8String], [[err localizedDescription] UTF8String]);
+        [BPUtils printInfo:ERROR withString:@"Could not write config to file %s\nERROR: %s\n", [self.configOutputFile UTF8String], [[err localizedDescription] UTF8String]];
     }
 }
 
@@ -698,7 +697,6 @@ static NSUUID *sessionID;
             return NO;
         }
     }
-
     if (self.screenshotsDirectory) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:self.screenshotsDirectory isDirectory:&isdir]) {
             if (!isdir) {

--- a/Source/Shared/BPConstants.h
+++ b/Source/Shared/BPConstants.h
@@ -9,12 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
-#define BP_DEFAULT_RUNTIME "iOS 12.2"
-#define BP_DEFAULT_DEVICE_TYPE "iPhone 7"
-#define BP_TM_PROTOCOL_VERSION 17
 #define BP_DAEMON_PROTOCOL_VERSION 26
+#define BP_DEFAULT_DEVICE_TYPE "iPhone 8"
+#define BP_DEFAULT_RUNTIME "iOS 12.2"
 #define BP_DEFAULT_XCODE_VERSION "10.2"
 #define BP_MAX_PROCESSES_PERCENT 0.75
+#define BP_TM_PROTOCOL_VERSION 17
 
 
 extern NSString * const kCFBundleIdentifier;

--- a/Source/Shared/BPUtils.h
+++ b/Source/Shared/BPUtils.h
@@ -49,10 +49,12 @@ typedef NS_ENUM(int, BPKind) {
  */
 + (BOOL)isBuildScript;
 
++ (NSString *)findExecutablePath:(NSString *)execName;
+
 /*!
  @discussion creates a temporary directory via mkdtemp(3)
  @param pathTemplate a path in which to create the temporary directory.
- It doesn't need to be unique since a unique identifier will be appended 
+ It doesn't need to be unique since a unique identifier will be appended
  to it.
  @param errPtr an error if creating the temporary directory failed.
  @return the path of the temporary directory created.
@@ -93,17 +95,17 @@ typedef NS_ENUM(int, BPKind) {
 }
 
 /*!
- 
+
  @brief Updates the config to expand any testsuites in the tests-to-run/skip into their individual test cases.
- 
+
  @discussion Bluepill supports passing in just the 'testsuite' as one of the tests to 'include' or 'exclude'.
  This method takes such items and expands them out so that @c BPPacker and @c SimulatorHelper can simply
  work with a list of fully qualified tests in the format of 'testsuite/testcase'.
- 
+
  @param config the @c BPConfiguration for this bluepill-runner
  @param xctTestFiles an NSArray of BPXCTestFile's to retrieve the tests from
  @return an updated @c BPConfiguration with testCasesToSkip and testCasesToRun that have had testsuites fully expanded into a list of 'testsuite/testcases'
- 
+
  */
 + (BPConfiguration *)normalizeConfiguration:(BPConfiguration *)config
                               withTestFiles:(NSArray *)xctTestFiles;
@@ -146,4 +148,13 @@ typedef BOOL (^BPRunBlock)(void);
  * @return trimmed test name
  */
 + (NSString *)trimTrailingParanthesesFromTestName:(NSString *)testName;
+
+/*!
+ * @discussion loads json mapping file from given absolute path
+ * @param filePath the absolute path of the input json mapping file
+ * @param errPtr an error if loading json mapping fails for some reason
+ * @return a dictionary with the mappings
+ */
++ (NSDictionary *)loadSimpleJsonFile:(NSString *)filePath withError:(NSError **)errPtr;
+
 @end

--- a/Source/Shared/BPUtils.m
+++ b/Source/Shared/BPUtils.m
@@ -121,6 +121,14 @@ static BOOL quiet = NO;
                            userInfo:@{NSLocalizedDescriptionKey: msg}];
 }
 
++ (NSString *)findExecutablePath:(NSString *)execName {
+    NSString *argv0 = [[[NSProcessInfo processInfo] arguments] objectAtIndex:0];
+    NSString *execPath = [[argv0 stringByDeletingLastPathComponent] stringByAppendingPathComponent:execName];
+    if (![[NSFileManager defaultManager] isExecutableFileAtPath:execPath]) {
+        return nil;
+    }
+    return execPath;
+}
 
 + (NSString *)mkdtemp:(NSString *)template withError:(NSError **)errPtr {
     char *dir = strdup([[template stringByAppendingString:@"_XXXXXX"] UTF8String]);
@@ -148,10 +156,10 @@ static BOOL quiet = NO;
     return ret;
 }
 
-
+// Expands the exclude or skipped tests, for example into all test methods if test class is mentioned
 + (BPConfiguration *)normalizeConfiguration:(BPConfiguration *)config
                               withTestFiles:(NSArray *)xctTestFiles {
-    
+
     config = [config mutableCopy];
     NSMutableSet *testsToRun = [NSMutableSet new];
     NSMutableSet *testsToSkip = [NSMutableSet new];
@@ -222,18 +230,18 @@ static BOOL quiet = NO;
 
 /*!
  @brief expand testcases into a list of fully expanded testcases in the form of 'testsuite/testcase'.
- 
+
  @discussion searches the given .xctest bundle's entire list of actual testcases
  (that are in the form of 'testsuite/testcase') for testcases that belong to testsuites
  that were provided in the configTestCases.
- 
+
  @param testCases a list of testcases: each item is either a 'testsuite' or a 'testsuite/testcase'.
  @return a @c NSArray of all the expanded 'testsuite/testcase' items that match the given configTestCases.
- 
+
  */
 + (NSArray *)expandTests:(NSArray *)testCases withTestFile:(BPXCTestFile *)testFile {
     NSMutableArray *expandedTestCases = [NSMutableArray new];
-    
+
     for (NSString *testCase in testCases) {
         if ([testCase rangeOfString:@"/"].location == NSNotFound) {
             [testFile.allTestCases enumerateObjectsUsingBlock:^(NSString *actualTestCase, NSUInteger idx, BOOL *stop) {
@@ -247,6 +255,7 @@ static BOOL quiet = NO;
     }
     return expandedTestCases;
 }
+
 + (NSString *)getXcodeRuntimeVersion {
     NSString *xcodeVersion = [BPUtils runShell:@"xcodebuild -version"];
     NSArray *versionStrArray = [xcodeVersion componentsSeparatedByString:@"\n"];
@@ -285,6 +294,18 @@ static BOOL quiet = NO;
         return nil;
     }
     return [testName substringWithRange:regexMatches.firstObject.range];
+}
+
++ (NSDictionary *)loadSimpleJsonFile:(NSString *)filePath
+                           withError:(NSError **)errPtr {
+    NSData *data = [NSData dataWithContentsOfFile:filePath
+                                          options:NSDataReadingMappedIfSafe
+                                            error:errPtr];
+    if (!data) return nil;
+
+    return [NSJSONSerialization JSONObjectWithData:data
+                                           options:NSJSONReadingAllowFragments
+                                             error:errPtr];
 }
 
 @end

--- a/Source/Shared/BPXCTestFile.h
+++ b/Source/Shared/BPXCTestFile.h
@@ -33,7 +33,7 @@
                           andUITargetAppPath:(NSString *)UITargetAppPath
                                    withError:(NSError **)errPtr;
 
-+ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*) dict
++ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*)dict
                               withTestRoot:(NSString *)testRoot
                               andXcodePath:(NSString *)xcodePath
                                   andError:(NSError **)errPtr;

--- a/Source/Shared/BPXCTestFile.m
+++ b/Source/Shared/BPXCTestFile.m
@@ -98,7 +98,6 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
         [testClass addTestCase:[[BPTestCase alloc] initWithName:parts[1]]];
     }
 
-
     xcTestFile.testClasses = [NSArray arrayWithArray:allClasses];
     return xcTestFile;
 }


### PR DESCRIPTION
Do not look for `bp` binary on `PATH` and simply fail if it is not found adjacent to the `bluepill` binary.

Also did some refactoring, cleanup and improvements like...
1. Moved a helper method to utils
2. Enhancing error messages and better error handling
3. Fixing asserts in tests
4. Renaming variables

\cc @ob @jmkk Please review.