### PR TITLE
[Master] Some refactoring and fail if bp binary is not found adjacent to bluepill binary

### DIFF
--- a/bluepill/src/BPPacker.m
+++ b/bluepill/src/BPPacker.m
@@ -7,8 +7,9 @@
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
-#import "BPPacker.h"
+#import "bp/src/BPXCTestFile.h"
 #import "bp/src/BPUtils.h"
+#import "BPPacker.h"
 
 @implementation BPPacker
 
@@ -56,7 +57,7 @@
             }
         }
     }
-    
+
     NSUInteger testsPerGroup = MAX(1, totalTests / numBundles);
     NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
@@ -107,9 +108,12 @@
     }
 
     // load the config file
-    NSDictionary *testTimes = [self loadConfigFile:config.testTimeEstimatesJsonFile withError:errPtr];
-    if ((errPtr && *errPtr) || !testTimes) {
+    NSDictionary *testTimes = [BPUtils loadSimpleJsonFile:config.testTimeEstimatesJsonFile withError:errPtr];
+    if (errPtr && *errPtr) {
         [BPUtils printInfo:ERROR withString:@"%@", [*errPtr localizedDescription]];
+        return NULL;
+    } else if (!testTimes) {
+        [BPUtils printInfo:ERROR withString:@"Invalid test execution time data"];
         return NULL;
     }
 
@@ -161,14 +165,4 @@
     return sortedBundles;
 }
 
-+ (NSDictionary *)loadConfigFile:(NSString *)file withError:(NSError **)errPtr{
-    NSData *data = [NSData dataWithContentsOfFile:file
-                                          options:NSDataReadingMappedIfSafe
-                                            error:errPtr];
-    if (!data) return nil;
-
-    return [NSJSONSerialization JSONObjectWithData:data
-                                           options:kNilOptions
-                                             error:errPtr];
-}
 @end

--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -59,8 +59,7 @@
         NSNumber *isDirectory = nil;
         if (![url getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:&error]) {
             [BPUtils printInfo:ERROR withString:@"Failed to get resource from url %@", url];
-        }
-        else if (![isDirectory boolValue]) {
+        } else if (![isDirectory boolValue]) {
             if ([[url pathExtension] isEqualToString:@"xml"]) {
                 [BPUtils printInfo:DEBUGINFO withString:@"JUnit collecting: %@", [url path]];
                 NSString *path = [url path];

--- a/bluepill/src/BPRunner.h
+++ b/bluepill/src/BPRunner.h
@@ -16,7 +16,7 @@
 @property (nonatomic, strong) BPConfiguration *config;
 @property (nonatomic, strong) NSString *bpExecutable;
 @property (nonatomic, strong) NSMutableArray *nsTaskList;
-@property (nonatomic, strong) NSMutableDictionary* testHostForSimUDID;
+@property (nonatomic, strong) NSDictionary *testHostSimTemplates;
 
 /*!
  * @discussion get a BPRunnner to run tests
@@ -40,11 +40,12 @@
                     andNumber:(NSUInteger)number
                     andDevice:(NSString *)deviceID
            andCompletionBlock:(void (^)(NSTask * ))block;
+
 /**
  @discussion start running tests
  @return 1: test failures 0: pass -1: failed to run tests
  */
 - (int)runWithBPXCTestFiles:(NSArray<BPXCTestFile *>*)xcTestFiles;
-- (void) interrupt;
 
+- (void) interrupt;
 @end

--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -7,23 +7,23 @@
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
-#import "BPRunner.h"
-#import "BPPacker.h"
-#import "bp/src/BPUtils.h"
-#include <sys/sysctl.h>
-#include <sys/types.h>
-#include <mach/mach.h>
-#include <mach/processor_info.h>
-#include <mach/mach_host.h>
-#include <signal.h>
-#include <pwd.h>
 #import <AppKit/AppKit.h>
-#import "bp/src/BPSimulator.h"
 #import "bp/src/BPCreateSimulatorHandler.h"
+#import "bp/src/BPSimulator.h"
+#import "bp/src/BPStats.h"
 #import "bp/src/BPUtils.h"
 #import "bp/src/BPWaitTimer.h"
 #import "bp/src/SimulatorHelper.h"
-#import "bp/src/BPStats.h"
+#import "BPPacker.h"
+#import "BPRunner.h"
+
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <mach/processor_info.h>
+#include <pwd.h>
+#include <signal.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
 
 static int volatile interrupted = 0;
 
@@ -59,33 +59,12 @@ maxprocs(void)
 + (instancetype)BPRunnerWithConfig:(BPConfiguration *)config
                         withBpPath:(NSString *)bpPath {
     BPRunner *runner = [[BPRunner alloc] init];
-    runner.testHostForSimUDID = [[NSMutableDictionary alloc] init];
+    runner.testHostSimTemplates = [[NSMutableDictionary alloc] init];
     runner.config = config;
-    // Find the `bp` binary.
-
-    if (bpPath) {
-        runner.bpExecutable = bpPath;
-    } else {
-        NSString *argv0 = [[[NSProcessInfo processInfo] arguments] objectAtIndex:0];
-        NSString *bp = [[argv0 stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"bp"];
-        if (![[NSFileManager defaultManager] isExecutableFileAtPath:bp]) {
-            // Search the PATH for a bp executable
-            BOOL foundIt = false;
-            NSString *path = [[[NSProcessInfo processInfo] environment] objectForKey:@"PATH"];
-            for (NSString *dir in [path componentsSeparatedByString:@":"]) {
-                bp = [dir stringByAppendingPathComponent:@"bp"];
-                if ([[NSFileManager defaultManager] isExecutableFileAtPath:bp]) {
-                    foundIt = true;
-                    break;
-                }
-            }
-            if (!foundIt) {
-                fprintf(stderr, "ERROR: I couldn't find the `bp` executable anywhere.\n"
-                        "Please put it somewhere in your PATH. (Ideally next to `bluepill`.\n");
-                return nil;
-            }
-        }
-        runner.bpExecutable = bp;
+    runner.bpExecutable = bpPath ?: [BPUtils findExecutablePath:@"bp"];
+    if (!runner.bpExecutable) {
+        fprintf(stderr, "ERROR: Unable to find bp executable.\n");
+        return nil;
     }
     return runner;
 }
@@ -115,7 +94,7 @@ maxprocs(void)
         cfg.environmentVariables = bundle.environmentVariables;
     }
     if (self.config.cloneSimulator) {
-        cfg.templateSimUDID = self.testHostForSimUDID[bundle.testHostPath];
+        cfg.templateSimUDID = self.testHostSimTemplates[bundle.testHostPath];
     }
     NSError *err;
     NSString *tmpFileName = [NSString stringWithFormat:@"%@/bluepill-%u-config",
@@ -175,11 +154,10 @@ maxprocs(void)
                                              NSWorkspaceLaunchAndHide;
     //launch Simulator.app without booting a simulator
     NSDictionary *configuration = @{NSWorkspaceLaunchConfigurationArguments:@[@"-StartLastDeviceOnLaunch",@"0"]};
-    NSRunningApplication *app = [[NSWorkspace sharedWorkspace]
-                                 launchApplicationAtURL:simulatorURL
-                                 options:launchOptions
-                                 configuration:configuration
-                                 error:errPtr];
+    NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:simulatorURL
+                                                                              options:launchOptions
+                                                                        configuration:configuration
+                                                                                error:errPtr];
     if (!app) {
         [BPUtils printInfo:ERROR withString:@"Launch Simulator.app returned error: %@", [*errPtr localizedDescription]];
         return nil;
@@ -203,7 +181,6 @@ maxprocs(void)
     if (sigaction(SIGHUP, &new_action, NULL) != 0) {
         [BPUtils printInfo:ERROR withString:@"Could not install SIGHUP handler: %s", strerror(errno)];
     }
-
     BPSimulator *bpSimulator = [BPSimulator simulatorWithConfiguration:self.config];
     NSUInteger numSims = [self.config.numSims intValue];
     [BPUtils printInfo:INFO withString:@"This is Bluepill %s", [BPUtils version]];
@@ -220,8 +197,8 @@ maxprocs(void)
         numSims = bundles.count;
     }
     if (self.config.cloneSimulator) {
-        self.testHostForSimUDID = [bpSimulator createSimulatorAndInstallAppWithBundles:xcTestFiles];
-        if ([self.testHostForSimUDID count] == 0) {
+        self.testHostSimTemplates = [bpSimulator createSimulatorAndInstallAppWithBundles:xcTestFiles];
+        if ([self.testHostSimTemplates count] == 0) {
             return 1;
         }
     }

--- a/bluepill/src/main.m
+++ b/bluepill/src/main.m
@@ -8,15 +8,15 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "BPApp.h"
-#import "bp/src/BPConfiguration.h"
-#import "BPRunner.h"
-#import "bp/src/BPUtils.h"
-#import "bp/src/BPStats.h"
-#import "bp/src/BPWriter.h"
-#import "BPReportCollector.h"
 #import <getopt.h>
 #import <libgen.h>
+#import "bp/src/BPConfiguration.h"
+#import "bp/src/BPStats.h"
+#import "bp/src/BPUtils.h"
+#import "bp/src/BPWriter.h"
+#import "BPApp.h"
+#import "BPReportCollector.h"
+#import "BPRunner.h"
 
 #include <sys/ioctl.h>
 #include <string.h>
@@ -88,7 +88,7 @@ int main(int argc, char * argv[]) {
 
         NSError *err = nil;
         if (![config processOptionsWithError:&err] || ![config validateConfigWithError:&err]) {
-            fprintf(stderr, "%s: invalid configuration\n\t%s\n",
+            fprintf(stderr, "%s: Invalid configuration\n\t%s\n",
                     basename(argv[0]), [[err localizedDescription] UTF8String]);
             exit(1);
         }
@@ -111,6 +111,10 @@ int main(int argc, char * argv[]) {
         [[BPStats sharedStats] endTimer:@"Normalizing Configuration" withResult:@"INFO"];
         // start a runner and let it fly
         BPRunner *runner = [BPRunner BPRunnerWithConfig:normalizedConfig withBpPath:nil];
+        if (!runner) {
+            fprintf(stderr, "ERROR: Unable to create Bluepill Runner.\n");
+            exit(1);
+        }
         rc = [runner runWithBPXCTestFiles:app.testBundles];
         if (config.outputDirectory) {
             // write the stats

--- a/bluepill/tests/BPAppTests.m
+++ b/bluepill/tests/BPAppTests.m
@@ -8,12 +8,12 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "bp/tests/BPTestHelper.h"
-#import "bp/src/BPConfiguration.h"
 #import "bluepill/src/BPApp.h"
+#import "bp/src/BPConfiguration.h"
 #import "bp/src/BPXCTestFile.h"
 #import "bp/src/BPUtils.h"
 #import "bp/src/BPConstants.h"
+#import "bp/tests/BPTestHelper.h"
 
 @interface BPAppTests : XCTestCase
 @property (nonatomic, strong) BPConfiguration* config;
@@ -23,7 +23,7 @@
 
 - (void)setUp {
     [super setUp];
-    
+
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
     self.config = [BPConfiguration new];
@@ -44,14 +44,15 @@
 - (void)testAppWithAppBundlePathNoError {
     NSError *error;
     self.config.testBundlePath = nil;
-    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    self.config.appBundlePath = [BPTestHelper sampleAppPath];
+    BPApp *app = [BPApp appWithConfig:self.config withError:&error];
     XCTAssertNil(error);
     XCTAssert(app.testBundles.count > 2);
 }
 
 - (void)testAppWithOnlyTestBundlePath {
     NSError *error;
-    BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    BPApp *app = [BPApp appWithConfig:self.config withError:&error];
     XCTAssertNil(error);
     XCTAssert(app.testBundles.count == 1);
     BPXCTestFile *testBundle = app.testBundles[0];

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -57,6 +57,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -72,6 +73,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -90,6 +92,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -112,6 +115,7 @@
 
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
     XCTAssert([runner.nsTaskList count] == 0);
@@ -129,6 +133,7 @@
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(app.testBundles[1].skipTestIdentifiers.count == 8);
     XCTAssert(rc != 0); // this runs tests that fail
@@ -142,6 +147,7 @@
                             withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
     BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
+    XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);
     XCTAssert([runner.nsTaskList count] == 0);

--- a/bluepill/tests/BPPackerTests.m
+++ b/bluepill/tests/BPPackerTests.m
@@ -7,12 +7,12 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "bp/tests/BPTestHelper.h"
-#import "bp/src/BPConfiguration.h"
-#import "bp/src/BPUtils.h"
 #import "bluepill/src/BPRunner.h"
 #import "bluepill/src/BPApp.h"
 #import "bluepill/src/BPPacker.h"
+#import "bp/tests/BPTestHelper.h"
+#import "bp/src/BPConfiguration.h"
+#import "bp/src/BPUtils.h"
 #import "bp/src/BPXCTestFile.h"
 #import "bp/src/BPConstants.h"
 
@@ -50,9 +50,9 @@
     self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.numSims = @2;
     BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
     app.testBundles[0].skipTestIdentifiers = @[@"BPSampleAppTests/testCase000", @"BPSampleAppTests/testCase001"];
 
-    XCTAssert(app != nil);
     NSArray<BPXCTestFile *> *bundles;
     bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];
     for (BPXCTestFile *file in app.testBundles) {
@@ -65,6 +65,7 @@
     self.config.testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.numSims = @8;
     BPApp *app = [BPApp appWithConfig:self.config withError:nil];
+    XCTAssert(app != nil);
     NSMutableArray *testCasesToSkip = [NSMutableArray new];
     for (BPXCTestFile *xctFile in app.testBundles) {
         [testCasesToSkip addObjectsFromArray:xctFile.allTestCases];

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -79,7 +79,7 @@ struct BPOptions {
     {'o', "output-dir", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "outputDirectory",
         "Directory where to put output log files (bluepill only)."},
     {'j', "test-time-estimates-json", BP_MASTER, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testTimeEstimatesJsonFile",
-        "Directory where Bluepill looks for input files with test execution time estimates (bluepill only)."},
+        "Path of the input file with test execution time estimates."},
     {'r', "runtime", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
         "What runtime to use."},
     {'x', "exclude", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
@@ -273,8 +273,7 @@ static NSUUID *sessionID;
                              atomically:NO
                                encoding:NSUTF8StringEncoding
                                   error:&err]) {
-        fprintf(stderr, "Could not write config to file %s\nERROR: %s\n",
-                [self.configOutputFile UTF8String], [[err localizedDescription] UTF8String]);
+        [BPUtils printInfo:ERROR withString:@"Could not write config to file %s\nERROR: %s\n", [self.configOutputFile UTF8String], [[err localizedDescription] UTF8String]];
     }
 }
 
@@ -659,7 +658,6 @@ static NSUUID *sessionID;
             return NO;
         }
     }
-
     if (self.screenshotsDirectory) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:self.screenshotsDirectory isDirectory:&isdir]) {
             if (!isdir) {

--- a/bp/src/BPConstants.h
+++ b/bp/src/BPConstants.h
@@ -15,6 +15,7 @@
 #define BP_DAEMON_PROTOCOL_VERSION 26
 #define BP_DEFAULT_XCODE_VERSION "11.1"
 #define BP_MAX_PROCESSES_PERCENT 0.75
+#define BP_TM_PROTOCOL_VERSION 17
 
 
 extern NSString * const kCFBundleIdentifier;

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -7,19 +7,19 @@
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
-#import "BPSimulator.h"
-#import "SimulatorHelper.h"
-#import "BPConfiguration.h"
-#import "BPConstants.h"
-#import "BPTreeParser.h"
-#import "BPUtils.h"
 #import <AppKit/AppKit.h>
 #import <sys/stat.h>
+#import "BPConfiguration.h"
+#import "BPConstants.h"
+#import "BPCreateSimulatorHandler.h"
+#import "BPSimulator.h"
 #import "BPTestBundleConnection.h"
 #import "BPTestDaemonConnection.h"
+#import "BPTreeParser.h"
+#import "BPUtils.h"
 #import "BPWaitTimer.h"
-#import "BPCreateSimulatorHandler.h"
 #import "PrivateHeaders/CoreSimulator/CoreSimulator.h"
+#import "SimulatorHelper.h"
 
 @interface BPSimulator()
 
@@ -40,7 +40,7 @@
 }
 
 - (NSMutableDictionary *)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles {
-    NSMutableDictionary* testHostForSimUDID = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary* testHostSimTemplates = [[NSMutableDictionary alloc] init];
     NSString *simulatorUDIDString = nil;
     NSError *error = nil;
     if (self.config.appBundlePath) {
@@ -50,7 +50,7 @@
             [BPUtils printInfo:ERROR withString:@"Create simualtor and install application failed with error: %@", error];
             return FALSE;
         }
-        testHostForSimUDID[self.config.appBundlePath] = simulatorUDIDString;
+        testHostSimTemplates[self.config.appBundlePath] = simulatorUDIDString;
         [BPUtils printInfo:INFO withString:@"Created sim template: %@ for app host: %@", simulatorUDIDString, self.config.appBundlePath];
     } else {
         // This is for testing in command line when we pass the xctestrun file
@@ -69,10 +69,10 @@
                 return FALSE;
             }
             [BPUtils printInfo:INFO withString:@"Created sim template: %@ for app host: %@", simulatorUDIDString, appPath];
-            testHostForSimUDID[appPath] = simulatorUDIDString;
+            testHostSimTemplates[appPath] = simulatorUDIDString;
         }
     }
-    return testHostForSimUDID;
+    return testHostSimTemplates;
 }
 
 - (NSString *)getErrorDescription:(NSError *__autoreleasing *)errPtr {
@@ -443,7 +443,6 @@
         hostBundleId = [SimulatorHelper bundleIdForPath:self.config.testRunnerAppPath];
     }
     // Create the environment for the host application
-
     NSMutableDictionary *argsAndEnv = [[NSMutableDictionary alloc] init];
     NSArray *argumentsArr = self.config.commandLineArguments ?: @[];
     NSMutableArray *commandLineArgs = [NSMutableArray array];
@@ -465,17 +464,6 @@
 
     argsAndEnv[@"args"] = [commandLineArgs copy];
     argsAndEnv[@"env"] = self.config.environmentVariables ?: @{};
-    NSMutableDictionary *appLaunchEnvironment = [NSMutableDictionary dictionaryWithDictionary:[SimulatorHelper appLaunchEnvironmentWithBundleID:hostBundleId device:self.device config:self.config]];
-    [appLaunchEnvironment addEntriesFromDictionary:argsAndEnv[@"env"]];
-    if (self.config.testing_CrashAppOnLaunch) {
-        appLaunchEnvironment[@"_BP_TEST_CRASH_ON_LAUNCH"] = @"YES";
-    }
-    if (self.config.testing_HangAppOnLaunch) {
-        appLaunchEnvironment[@"_BP_TEST_HANG_ON_LAUNCH"] = @"YES";
-    }
-    if (self.config.testing_crashOnAttempt) {
-        appLaunchEnvironment[@"_BP_TEST_CRASH_ON_ATTEMPT"] = [self.config.testing_crashOnAttempt stringValue];
-    }
 
     // Intercept stdout, stderr and post as simulator-output events
     NSString *stdout_stderr = [NSString stringWithFormat:@"%@/tmp/stdout_stderr_%@", self.device.dataPath, [[self.device UDID] UUIDString]];
@@ -490,17 +478,23 @@
                                             contents:nil
                                           attributes:nil];
 
-    NSMutableDictionary *appLaunchEnv = [appLaunchEnvironment mutableCopy];
-    [appLaunchEnv setObject:simStdoutRelativePath forKey:kOptionsStdoutKey];
-    [appLaunchEnv setObject:simStdoutRelativePath forKey:kOptionsStderrKey];
-    NSString *insertLibraryPath = [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/usr/lib/libXCTestBundleInject.dylib", self.config.xcodePath];
-    [appLaunchEnv setObject:insertLibraryPath forKey:@"DYLD_INSERT_LIBRARIES"];
-    [appLaunchEnv setObject:insertLibraryPath forKey:@"XCInjectBundleInto"];
-
     self.appOutput = [NSFileHandle fileHandleForReadingAtPath:simStdoutPath];
 
-    appLaunchEnvironment = [appLaunchEnv copy];
-
+    NSDictionary *appLaunchEnvironment = [SimulatorHelper appLaunchEnvironmentWithBundleID:hostBundleId device:self.device config:self.config];
+    NSMutableDictionary *mutableAppLaunchEnv = [appLaunchEnvironment mutableCopy];
+    NSString *insertLibraryPath = [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/usr/lib/libXCTestBundleInject.dylib", self.config.xcodePath];
+    [mutableAppLaunchEnv setObject:insertLibraryPath forKey:@"DYLD_INSERT_LIBRARIES"];
+    [mutableAppLaunchEnv setObject:insertLibraryPath forKey:@"XCInjectBundleInto"];
+    [mutableAppLaunchEnv setObject:simStdoutRelativePath forKey:kOptionsStdoutKey];
+    [mutableAppLaunchEnv setObject:simStdoutRelativePath forKey:kOptionsStderrKey];
+    [mutableAppLaunchEnv addEntriesFromDictionary:argsAndEnv[@"env"]];
+    if (self.config.testing_CrashAppOnLaunch) {
+        mutableAppLaunchEnv[@"_BP_TEST_CRASH_ON_LAUNCH"] = @"YES";
+    }
+    if (self.config.testing_HangAppOnLaunch) {
+        mutableAppLaunchEnv[@"_BP_TEST_HANG_ON_LAUNCH"] = @"YES";
+    }
+    appLaunchEnvironment = [mutableAppLaunchEnv copy];
     NSDictionary *options = @{
                               kOptionsArgumentsKey: argsAndEnv[@"args"],
                               kOptionsEnvironmentKey: appLaunchEnvironment,
@@ -559,7 +553,6 @@
             }
         });
     }];
-
 }
 
 - (void)deleteSimulatorWithCompletion:(void (^)(NSError *error, BOOL success))completion {

--- a/bp/src/BPUtils.h
+++ b/bp/src/BPUtils.h
@@ -49,10 +49,12 @@ typedef NS_ENUM(int, BPKind) {
  */
 + (BOOL)isBuildScript;
 
++ (NSString *)findExecutablePath:(NSString *)execName;
+
 /*!
  @discussion creates a temporary directory via mkdtemp(3)
  @param pathTemplate a path in which to create the temporary directory.
- It doesn't need to be unique since a unique identifier will be appended 
+ It doesn't need to be unique since a unique identifier will be appended
  to it.
  @param errPtr an error if creating the temporary directory failed.
  @return the path of the temporary directory created.
@@ -93,17 +95,17 @@ typedef NS_ENUM(int, BPKind) {
 }
 
 /*!
- 
+
  @brief Updates the config to expand any testsuites in the tests-to-run/skip into their individual test cases.
- 
+
  @discussion Bluepill supports passing in just the 'testsuite' as one of the tests to 'include' or 'exclude'.
  This method takes such items and expands them out so that @c BPPacker and @c SimulatorHelper can simply
  work with a list of fully qualified tests in the format of 'testsuite/testcase'.
- 
+
  @param config the @c BPConfiguration for this bluepill-runner
  @param xctTestFiles an NSArray of BPXCTestFile's to retrieve the tests from
  @return an updated @c BPConfiguration with testCasesToSkip and testCasesToRun that have had testsuites fully expanded into a list of 'testsuite/testcases'
- 
+
  */
 + (BPConfiguration *)normalizeConfiguration:(BPConfiguration *)config
                               withTestFiles:(NSArray *)xctTestFiles;
@@ -160,4 +162,13 @@ typedef BOOL (^BPRunBlock)(void);
  * @return the version
  */
 + (char *)version;
+
+/*!
+ * @discussion loads json mapping file from given absolute path
+ * @param filePath the absolute path of the input json mapping file
+ * @param errPtr an error if loading json mapping fails for some reason
+ * @return a dictionary with the mappings
+ */
++ (NSDictionary *)loadSimpleJsonFile:(NSString *)filePath withError:(NSError **)errPtr;
+
 @end

--- a/bp/src/BPXCTestFile.h
+++ b/bp/src/BPXCTestFile.h
@@ -33,7 +33,7 @@
                           andUITargetAppPath:(NSString *)UITargetAppPath
                                    withError:(NSError **)errPtr;
 
-+ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*) dict
++ (instancetype)BPXCTestFileFromDictionary:(NSDictionary<NSString *, NSString *>*)dict
                               withTestRoot:(NSString *)testRoot
                               andXcodePath:(NSString *)xcodePath
                                   andError:(NSError **)errPtr;

--- a/bp/src/BPXCTestFile.m
+++ b/bp/src/BPXCTestFile.m
@@ -98,7 +98,6 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
         [testClass addTestCase:[[BPTestCase alloc] initWithName:parts[1]]];
     }
 
-
     xcTestFile.testClasses = [NSArray arrayWithArray:allClasses];
     return xcTestFile;
 }

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -209,9 +209,8 @@ static void onInterrupt(int ignore) {
     BPXCTestFile *xctTestFile = [BPXCTestFile BPXCTestFileFromXCTestBundle:context.config.testBundlePath
                                                           andHostAppBundle:testHostPath
                                                                  withError:&error];
-    NSAssert(xctTestFile != nil, @"Failed to load testcases from %@", [error localizedDescription]);
+    NSAssert(xctTestFile != nil, @"Failed to load testcases from: %@; Error: %@", context.config.testBundlePath, [error localizedDescription]);
     context.config.allTestCases = [[NSArray alloc] initWithArray: xctTestFile.allTestCases];
-
 
     context.attemptNumber = self.retries + 1;
     self.context = context; // Store the context on self so that it's accessible to the interrupt handler in the loop
@@ -230,10 +229,9 @@ static void onInterrupt(int ignore) {
         NSError *err;
         NSString *tmpFileName = [BPUtils mkstemp:[NSString stringWithFormat:@"%@/%lu-bp-stdout-%u", NSTemporaryDirectory(), context.attemptNumber, getpid()]
                                        withError:&err];
-        simulatorLogPath = tmpFileName;
-        if (!tmpFileName) {
-            simulatorLogPath = [NSString stringWithFormat:@"/tmp/%lu-simulator.log", context.attemptNumber];
-            [BPUtils printInfo:ERROR withString:@"ERROR: %@\nLeaving log in %@", [err localizedDescription], simulatorLogPath];
+        simulatorLogPath = tmpFileName? tmpFileName : [NSString stringWithFormat:@"/tmp/%lu-simulator.log", context.attemptNumber];
+        if (err) {
+            [BPUtils printInfo:ERROR withString:@"Error: %@\nLeaving log in %@", [err localizedDescription], simulatorLogPath];
         }
     }
 

--- a/bp/src/SimulatorHelper.h
+++ b/bp/src/SimulatorHelper.h
@@ -33,6 +33,7 @@
 
 /*!
  * @discussion get the path of the environment configuration file
+ * @param config the configuration object
  * @return return the path to the test configuration file.
  */
 + (NSString *)testEnvironmentWithConfiguration:(BPConfiguration *)config;


### PR DESCRIPTION
**TL;DR** Rebasing changes from https://github.com/linkedin/bluepill/pull/378 to be merged into master

**Major change:** Do not look for bp binary on PATH and simply fail if it is not found adjacent to the bluepill binary.

Also did some refactoring, cleanup and improvements like...
1. Moved a helper method to utils
2. Enhancing error messages and better error handling
3. Fixing asserts in tests
4. Renaming variables

**P.S:** Works best if pushed after https://github.com/linkedin/bluepill/pull/379

\cc @ob @jmkk Please review.