### PR TITLE
Deprecating clone-simulator config and defaulting it to always ON

### DIFF
--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -14,6 +14,7 @@
 #import "bp/src/BPUtils.h"
 #import "bp/src/BPWaitTimer.h"
 #import "bp/src/SimulatorHelper.h"
+#import "bp/BPVersion.h"
 #import "BPPacker.h"
 #import "BPRunner.h"
 

--- a/bluepill/src/main.m
+++ b/bluepill/src/main.m
@@ -92,6 +92,12 @@ int main(int argc, char * argv[]) {
                     basename(argv[0]), [[err localizedDescription] UTF8String]);
             exit(1);
         }
+        err = nil;
+        if (![config fillSimDeviceTypeAndRuntimeWithError:&err]) {
+            fprintf(stderr, "%s: Unable to fill Sim device type and/or runtime\n\t%s\n",
+                    basename(argv[0]), [[err localizedDescription] UTF8String]);
+            exit(1);
+        }
         [[BPStats sharedStats] endTimer:@"Bluepill Initializing" withResult:@"INFO"];
         [[BPStats sharedStats] startTimer:@"Loading App"];
         BPApp *app = [BPApp appWithConfig:config withError:&err];

--- a/bluepill/src/main.m
+++ b/bluepill/src/main.m
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 #import <getopt.h>
 #import <libgen.h>
+#import "bp/BPVersion.h"
 #import "bp/src/BPConfiguration.h"
 #import "bp/src/BPStats.h"
 #import "bp/src/BPUtils.h"

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -72,7 +72,7 @@
     NSError *err;
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-    BPRunner *runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
@@ -87,7 +87,7 @@
     NSError *err;
     BPApp *app = [BPApp appWithConfig:self.config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-    BPRunner *runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
@@ -106,9 +106,7 @@
     BPRunner *runner;
     BPApp *app = [BPApp appWithConfig:config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-
-    // Testing that the sim templates get created
-    runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert([runner.testHostSimTemplates count] > 0);
@@ -130,7 +128,7 @@
     NSError *err;
     BPApp *app = [BPApp appWithConfig:config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-    BPRunner *runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
@@ -152,7 +150,7 @@
     XCTAssertNil(err);
     BPApp *app = [BPApp appWithConfig:config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-    BPRunner *runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     for (BPXCTestFile *testBundle in app.testBundles) {
@@ -172,7 +170,7 @@
     NSError *err;
     BPApp *app = [BPApp appWithConfig:config withError:&err];
     NSString *bpPath = [BPTestHelper bpExecutablePath];
-    BPRunner *runner = [BPRunner BPRunnerWithConfig:config withBpPath:bpPath];
+    BPRunner *runner = [BPRunner BPRunnerWithConfig:self.config withBpPath:bpPath];
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -88,7 +88,6 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSString *simulatorPreferencesFile;
 @property (nonatomic, strong) NSString *scriptFilePath;
 @property (nonatomic) BOOL headlessMode;
-@property (nonatomic) BOOL cloneSimulator;
 @property (nonatomic, strong) NSNumber *numSims;
 @property (nonatomic) BOOL listTestsOnly;
 @property (nonatomic) BOOL quiet;
@@ -161,6 +160,15 @@ typedef NS_ENUM(NSInteger, BPProgram) {
  @return True if we managed to process the options successfully. False otherwise.
  */
 - (BOOL)processOptionsWithError:(NSError **)errPtr;
+
+/*!
+ Validates and fills in simDeviceType and simRunTime based on default values if corresponding input config are missing
+
+ @param errPtr The error message in case of invalid input or failure to fill-in
+
+ @return True if the configs are valid and/or values are filled-in. False otherwise.
+ */
+- (BOOL)fillSimDeviceTypeAndRuntimeWithError:(NSError **)errPtr;
 
 /**
  Validate that the current configuration would work with Bluepill.

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -798,7 +798,6 @@ static NSUUID *sessionID;
             return NO;
         }
     }
-
     if (self.screenshotsDirectory) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:self.screenshotsDirectory isDirectory:&isdir]) {
             if (!isdir) {

--- a/bp/src/BPSimulator.h
+++ b/bp/src/BPSimulator.h
@@ -26,8 +26,6 @@
 
 + (instancetype)simulatorWithConfiguration:(BPConfiguration *)config;
 
-- (void)createSimulatorWithDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion;
-
 - (void)cloneSimulatorWithDeviceName:(NSString *)deviceName completion:(void (^)(NSError *))completion;
 
 - (void)setParserStateCompleted;
@@ -56,7 +54,7 @@
  The number of template simulators is equal to the number of test hosts
  @return a dictionary with key to be the host bundle path and value to be the template simulator
  */
-- (NSMutableDictionary*)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles;
+- (NSMutableDictionary*)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles withSimTemplate:(NSString *)simTemplate;
 
 - (void)deleteTemplateSimulator;
 

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -45,6 +45,7 @@
 }
 
 - (NSMutableDictionary *)createSimulatorAndInstallAppWithBundles:(NSArray<BPXCTestFile *>*)testBundles withSimTemplate:(NSString *)simTemplateUDID {
+    NSMutableDictionary* testHostSimTemplates = [[NSMutableDictionary alloc] init];
     NSError *error = nil;
     NSString *simulatorUDIDString = nil;
     SimServiceContext *sc = [SimServiceContext sharedServiceContextForDeveloperDir:self.config.xcodePath error:&error];
@@ -81,8 +82,8 @@
             [BPUtils printInfo:ERROR withString:@"Create simulator and install application failed with error: %@", error];
             return nil;
         }
-        self.testHostSimTemplates[self.config.appBundlePath] = simulatorUDIDString;
-        [BPUtils printInfo:INFO withString:@"Installed app host: %@ on sim template: %@", self.config.appBundlePath, simulatorUDIDString];
+        testHostSimTemplates[self.config.appBundlePath] = simulatorUDIDString;
+        [BPUtils printInfo:INFO withString:@"Created sim template: %@ for app host: %@", simulatorUDIDString, self.config.appBundlePath];
     } else {
         // This is for testing in command line when we pass the xctestrun file
         NSMutableSet *hostBundles = [[NSMutableSet alloc] init];
@@ -108,10 +109,10 @@
                 return FALSE;
             }
             [BPUtils printInfo:INFO withString:@"Created sim template: %@ for app host: %@", simulatorUDIDString, appPath];
-            self.testHostSimTemplates[appPath] = simulatorUDIDString;
+            testHostSimTemplates[appPath] = simulatorUDIDString;
         }
     }
-    return self.testHostSimTemplates;
+    return testHostSimTemplates;
 }
 
 - (NSString *)getErrorDescription:(NSError *__autoreleasing *)errPtr {

--- a/bp/src/BPStats.h
+++ b/bp/src/BPStats.h
@@ -11,7 +11,6 @@
 
 #define SIMULATOR_LIFETIME(x)    [NSString stringWithFormat:@"Simulator %@", (x)]
 #define CLONE_SIMULATOR(x)       [NSString stringWithFormat:@"[Attempt %lu] Clone Simulator", (x)]
-#define CREATE_SIMULATOR(x)      [NSString stringWithFormat:@"[Attempt %lu] Create Simulator", (x)]
 #define REUSE_SIMULATOR(x)       [NSString stringWithFormat:@"[Attempt %lu] Reuse Simulator", (x)]
 #define INSTALL_APPLICATION(x)   [NSString stringWithFormat:@"[Attempt %lu] Install Application", (x)]
 #define UNINSTALL_APPLICATION(x) [NSString stringWithFormat:@"[Attempt %lu] Uninstall Application", (x)]

--- a/bp/src/main.m
+++ b/bp/src/main.m
@@ -58,6 +58,12 @@ int main(int argc, char * argv[]) {
                     basename(argv[0]), [[err localizedDescription] UTF8String]);
             exit(1);
         }
+        err = nil;
+        if (![config fillSimDeviceTypeAndRuntimeWithError:&err]) {
+            fprintf(stderr, "%s: Unable to fill Sim device type and/or runtime\n\t%s\n",
+                    basename(argv[0]), [[err localizedDescription] UTF8String]);
+            exit(1);
+        }
 
         BPExitStatus exitCode;
         Bluepill *bp = [[Bluepill alloc] initWithConfiguration:config];

--- a/bp/tests/BPConfigurationTests.m
+++ b/bp/tests/BPConfigurationTests.m
@@ -35,7 +35,8 @@
     NSString *resourcePath = [BPTestHelper resourceFolderPath];
     NSString *configFile = [resourcePath stringByAppendingPathComponent:@"testConfig-busted.json"];
     [config loadConfigFile:configFile withError:&error];
-    [config validateConfigWithError:&error];
+    [config validateConfigWithError:nil];
+    [config fillSimDeviceTypeAndRuntimeWithError:&error];
     XCTAssertNotNil(error);
     NSString *expected = [[NSString alloc] initWithFormat:@"runtime must be a string like '%s'.", BP_DEFAULT_RUNTIME];
     XCTAssert([[error localizedDescription] isEqualToString:expected], @"Wrong error message: %@", [error localizedDescription]);


### PR DESCRIPTION
The clone-simulator config is deprecated and need not be passed. The clone simulator feature is always ON in Bluepill going forward.

@ob Can you please take a look?