### PR TITLE
Enabling github workflows to run tests on all PRs

### DIFF
--- a/.github/workflows/CI-PR.yml
+++ b/.github/workflows/CI-PR.yml
@@ -1,9 +1,6 @@
 name: CI-PR
 
-on:
-  pull_request:
-    branches: 
-      - master
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
Removing a limitation of running tests only on PRs based on the `master` branch and enabling it for all PRs. This will enable Github actions for all PRs including those that are based on branches other than the `master`.

Ref: https://github.com/linkedin/bluepill/issues/386

\cc @ob 