### PR TITLE
Remove install cocoapods step since cocoapods is pre-installed

### DIFF
--- a/.github/workflows/CI-release.yml
+++ b/.github/workflows/CI-release.yml
@@ -38,8 +38,6 @@ jobs:
         files: 'build/*.zip'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install Cocoapods
-      run: brew install cocoapods
     - name: Publish to Cocoapods
       run: pod trunk push Bluepill.podspec
       env:


### PR DESCRIPTION
ref https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#macos-1015