### PR TITLE
Splitting test bundles based on estimates test execution times

### DIFF
--- a/bluepill/src/BPPacker.h
+++ b/bluepill/src/BPPacker.h
@@ -19,8 +19,8 @@
  * @param config The configuration file for this bluepill-runner
  * @return An NSMutableArray of BPXCTestFile's with the tests packed into bundles.
  */
-+ (NSMutableArray<BPXCTestFile *> *)packTests:(NSArray *)xcTestFiles
-                configuration:(BPConfiguration *)config
-                     andError:(NSError **)errPtr;
++ (NSArray<BPXCTestFile *> *)packTests:(NSArray <BPXCTestFile *> *)xcTestFiles
+                         configuration:(BPConfiguration *)config
+                              andError:(NSError **)errPtr;
 
 @end

--- a/bluepill/src/BPPacker.m
+++ b/bluepill/src/BPPacker.m
@@ -13,9 +13,9 @@
 
 @implementation BPPacker
 
-+ (NSMutableArray<BPXCTestFile *> *)packTests:(NSArray<BPXCTestFile *> *)xcTestFiles
-                                configuration:(BPConfiguration *)config
-                                     andError:(NSError **)errPtr {
++ (NSArray<BPXCTestFile *> *)packTests:(NSArray<BPXCTestFile *> *)xcTestFiles
+                         configuration:(BPConfiguration *)config
+                              andError:(NSError **)errPtr {
     if (!config.testTimeEstimatesJsonFile) {
         return [self packTestsByCount:xcTestFiles configuration:config andError:errPtr];
     } else {
@@ -23,13 +23,20 @@
     }
 }
 
-+ (NSMutableArray<BPXCTestFile *> *)packTestsByCount:(NSArray<BPXCTestFile *> *)xcTestFiles
-                                       configuration:(BPConfiguration *)config
-                                            andError:(NSError **)errPtr {
+/*!
+ * @discussion Sort .xctest bundles by test counts.
+ * @param xcTestFiles An NSArray of BPXCTestFile's to pack
+ * @param config The configuration file for this bluepill-runner
+ * @param errPtr Error, if any
+ * @return An NSMutableArray of BPXCTestFile's with the tests packed into bundles.
+ */
++ (NSArray<BPXCTestFile *> *)packTestsByCount:(NSArray<BPXCTestFile *> *)xcTestFiles
+                                configuration:(BPConfiguration *)config
+                                     andError:(NSError **)errPtr {
     [BPUtils printInfo:INFO withString:@"Packing test bundles based on test counts."];
     NSArray *testCasesToRun = config.testCasesToRun;
     NSArray *noSplit = config.noSplit;
-    NSUInteger numBundles = [config.numSims integerValue];
+    NSUInteger numBundles = [[config numSims] integerValue];
     NSArray *sortedXCTestFiles = [xcTestFiles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
         NSUInteger numTests1 = [(BPXCTestFile *)obj1 numTests];
         NSUInteger numTests2 = [(BPXCTestFile *)obj2 numTests];
@@ -40,7 +47,7 @@
                      "Perhaps you forgot to 'build-for-testing'? (Cmd + Shift + U) in Xcode.");
         return NULL;
     }
-    NSMutableDictionary *testsToRunByTestFilePath = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary<NSString *, NSSet *> *testsToRunByFilePath = [[NSMutableDictionary alloc] init];
     NSUInteger totalTests = 0;
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
         if (![noSplit containsObject:[xctFile name]]) {
@@ -52,7 +59,7 @@
                 [bundleTestsToRun minusSet:[[NSSet alloc] initWithArray:config.testCasesToSkip]];
             }
             if (bundleTestsToRun.count > 0) {
-                testsToRunByTestFilePath[xctFile.testBundlePath] = bundleTestsToRun;
+                testsToRunByFilePath[xctFile.testBundlePath] = bundleTestsToRun;
                 totalTests += bundleTestsToRun.count;
             }
         }
@@ -61,7 +68,7 @@
     NSUInteger testsPerGroup = MAX(1, totalTests / numBundles);
     NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
     for (BPXCTestFile *xctFile in sortedXCTestFiles) {
-        NSArray *bundleTestsToRun = [[testsToRunByTestFilePath[xctFile.testBundlePath] allObjects] sortedArrayUsingSelector:@selector(compare:)];
+        NSArray *bundleTestsToRun = [[testsToRunByFilePath[xctFile.testBundlePath] allObjects] sortedArrayUsingSelector:@selector(compare:)];
         NSUInteger bundleTestsToRunCount = [bundleTestsToRun count];
         // if the xctfile is in nosplit list, don't pack it
         if ([noSplit containsObject:[xctFile name]] || (bundleTestsToRunCount <= testsPerGroup && bundleTestsToRunCount > 0)) {
@@ -97,9 +104,66 @@
     return bundles;
 }
 
-+ (NSMutableArray<BPXCTestFile *> *)packTestsByTime:(NSArray<BPXCTestFile *> *)xcTestFiles
-                                      configuration:(BPConfiguration *)config
-                                           andError:(NSError **)errPtr {
+/*!
+ * @discussion Ideally each test bundle should not take more than totalTime/numSims, so split bundles which take longer.
+ * @param config The configuration file for this bluepill-runner
+ * @param testTimes Mapping of a test name to it's estimated execution time
+ * @param xcTestFiles An array of xctestfiles to pack
+ * @return An array of split test bundles
+ */
++ (NSArray<BPXCTestFile *> *)splitXCTestBundlesWithConfig:(BPConfiguration *)config
+                                            withTestTimes:(NSDictionary<NSString *, NSNumber *> *)testTimes
+                                           andXCTestFiles:(NSArray<BPXCTestFile *> *)xcTestFiles {
+    NSArray *noSplit = config.noSplit;
+    double totalTime = [BPUtils getTotalTimeWithConfig:config
+                                             testTimes:testTimes
+                                        andXCTestFiles:xcTestFiles];
+    // Maximum allowed bundle time to optimize the sim track execution long pole which is maximum of all track times
+    double optimalBundleTime = totalTime / [[config numSims] floatValue];
+    [BPUtils printInfo:INFO withString:@"Optimal Bundle Time is around %f seconds.", optimalBundleTime];
+    NSDictionary<NSString *, NSSet *> *testsToRunByFilePath = [BPUtils getTestsToRunByFilePathWithConfig:config
+                                                                                          andXCTestFiles:xcTestFiles];
+    NSDictionary<NSString *, NSNumber *> *testEstimatesByFilePath = [BPUtils getTestEstimatesByFilePathWithConfig:config
+                                                                                                        testTimes:testTimes
+                                                                                                   andXCTestFiles:xcTestFiles];
+
+    NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
+    for (BPXCTestFile *xctFile in xcTestFiles) {
+        NSArray *bundleTestsToRun = [[testsToRunByFilePath[xctFile.testBundlePath] allObjects] sortedArrayUsingSelector:@selector(compare:)];
+        NSNumber *estimatedBundleTime = testEstimatesByFilePath[xctFile.testBundlePath];
+        // If the bundle is small enough, do not split. Also do not split if the bundle is in no_split list.
+        if ([noSplit containsObject:[xctFile name]] || [estimatedBundleTime doubleValue] < optimalBundleTime) {
+            BPXCTestFile *bundle = [self makeBundle:xctFile withTests:bundleTestsToRun startAt:0 numTests:[bundleTestsToRun count] estimatedTime:estimatedBundleTime];
+            [bundles addObject:bundle];
+            continue;
+        }
+        for (int i = 0; i < [bundleTestsToRun count];) {
+            double splitExecTime = 0.0;
+            NSUInteger startIndex = i;
+            while(splitExecTime < optimalBundleTime && i < [bundleTestsToRun count]) {
+                NSString *test = [bundleTestsToRun objectAtIndex:i];
+                if ([testTimes objectForKey:test]) {
+                    if (splitExecTime + [testTimes[test] doubleValue] <= optimalBundleTime) {
+                        splitExecTime += [testTimes[test] doubleValue];
+                    } else {
+                        break;
+                    }
+                }
+                i++;
+            }
+            // Make a bundle out of current xctFile
+            BPXCTestFile *bundle = [self makeBundle:xctFile withTests:bundleTestsToRun startAt:startIndex numTests:(i-startIndex) estimatedTime:[NSNumber numberWithDouble:splitExecTime]];
+            [bundles addObject:bundle];
+        }
+    }
+    [BPUtils printInfo:INFO withString:@"Splitted %lu bundles into %lu bundles.", [xcTestFiles count], [bundles count]];
+
+    return bundles;
+}
+
++ (NSArray<BPXCTestFile *> *)packTestsByTime:(NSArray<BPXCTestFile *> *)xcTestFiles
+                               configuration:(BPConfiguration *)config
+                                    andError:(NSError **)errPtr {
     [BPUtils printInfo:INFO withString:@"Packing based on individual test execution times in file path: %@", config.testTimeEstimatesJsonFile];
     if (xcTestFiles.count == 0) {
         BP_SET_ERROR(errPtr, @"Found no XCTest files.\n"
@@ -108,7 +172,7 @@
     }
 
     // load the config file
-    NSDictionary *testTimes = [BPUtils loadSimpleJsonFile:config.testTimeEstimatesJsonFile withError:errPtr];
+    NSDictionary<NSString *, NSNumber *> *testTimes = [BPUtils loadSimpleJsonFile:config.testTimeEstimatesJsonFile withError:errPtr];
     if (errPtr && *errPtr) {
         [BPUtils printInfo:ERROR withString:@"%@", [*errPtr localizedDescription]];
         return NULL;
@@ -117,41 +181,14 @@
         return NULL;
     }
 
-    NSMutableDictionary *estimatedTimesByTestFilePath = [[NSMutableDictionary alloc] init];
-    NSArray *testCasesToRun = config.testCasesToRun;
+    [BPUtils printInfo:INFO withString:@"Test cases to run from the config: %lu", [config.testCasesToRun count]];
 
-    double totalTime = 0.0;
-    for (BPXCTestFile *xctFile in xcTestFiles) {
-        NSMutableSet *bundleTestsToRun = [[NSMutableSet alloc] initWithArray:[xctFile allTestCases]];
-        if (testCasesToRun) {
-            [bundleTestsToRun intersectSet:[[NSSet alloc] initWithArray:testCasesToRun]];
-        }
-        if (config.testCasesToSkip && [config.testCasesToSkip count] > 0) {
-            [bundleTestsToRun minusSet:[[NSSet alloc] initWithArray:config.testCasesToSkip]];
-        }
-        if (bundleTestsToRun.count > 0) {
-            double __block testBundleExecutionTime = 0.0;
-            [bundleTestsToRun enumerateObjectsUsingBlock:^(id _Nonnull test, BOOL * _Nonnull stop) {
-                // TODO: Assign a sensible default if the estimate is not given
-                if ([testTimes objectForKey:test]) {
-                    testBundleExecutionTime += [[testTimes objectForKey:test] doubleValue];
-                }
-            }];
-            estimatedTimesByTestFilePath[xctFile.testBundlePath] = [NSNumber numberWithDouble:testBundleExecutionTime];
-            totalTime += testBundleExecutionTime;
-        }
-    }
-    assert([estimatedTimesByTestFilePath count] == [xcTestFiles count]);
+    NSArray<BPXCTestFile *> * bundles = [self splitXCTestBundlesWithConfig:config
+                                                             withTestTimes:testTimes
+                                                            andXCTestFiles:xcTestFiles];
 
-    NSMutableArray<BPXCTestFile *> *bundles = [[NSMutableArray alloc] init];
-    for (BPXCTestFile *xctFile in xcTestFiles) {
-        BPXCTestFile *bundle = [xctFile copy];
-        bundle.skipTestIdentifiers = config.testCasesToSkip;
-        [bundle setEstimatedExecutionTime:estimatedTimesByTestFilePath[xctFile.testBundlePath]];
-        [bundles addObject:bundle];
-    }
     // Sort bundles by execution times from longest to shortest
-    NSMutableArray *sortedBundles = [NSMutableArray arrayWithArray:[bundles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
+    NSArray *sortedBundles = [bundles sortedArrayUsingComparator:^NSComparisonResult(id _Nonnull obj1, id _Nonnull obj2) {
         NSNumber *estimatedTime1 = [(BPXCTestFile *)obj1 estimatedExecutionTime];
         NSNumber *estimatedTime2 = [(BPXCTestFile *)obj2 estimatedExecutionTime];
         if ([estimatedTime1 doubleValue] < [estimatedTime2 doubleValue]) {
@@ -161,8 +198,37 @@
         } else {
             return NSOrderedSame;
         }
-    }]];
+    }];
+    [BPUtils printInfo:INFO withString:@"The test bundles after splitting based on time and sorting from longest to shortest are..."];
+    NSNumberFormatter *fmt = [[NSNumberFormatter alloc] init];
+    [fmt setPositiveFormat:@".02"];
+    for (BPXCTestFile *bundle in sortedBundles) {
+        [BPUtils printInfo:INFO withString:@"%@ estimated to take %@ seconds and skips %lu out of %lu tests.",
+                                                     bundle.name,
+                                                     [fmt stringFromNumber:bundle.estimatedExecutionTime],
+                                                     (unsigned long)[bundle.skipTestIdentifiers count],
+                                                     (unsigned long)[bundle.allTestCases count]];
+    }
     return sortedBundles;
+}
+
++ (BPXCTestFile *)makeBundle:(BPXCTestFile *)xctFile
+                   withTests:(NSArray *)bundleTestsToRun
+                     startAt:(NSUInteger)location
+                    numTests:(NSUInteger)length
+               estimatedTime:(NSNumber *)splitExecutionTime {
+    NSMutableArray *testsToSkip = [NSMutableArray arrayWithArray:bundleTestsToRun];
+    NSRange range = NSMakeRange(location, length);
+    [BPUtils printInfo:INFO withString:@"%@: Including range: (%lu, %lu)", xctFile.testBundlePath, (unsigned long)range.location, (unsigned long)range.length];
+    [testsToSkip removeObjectsInArray:[bundleTestsToRun subarrayWithRange:range]];
+    [testsToSkip addObjectsFromArray:xctFile.skipTestIdentifiers];
+    [testsToSkip sortUsingSelector:@selector(compare:)];
+
+    BPXCTestFile *bundle = [xctFile copy];
+    [bundle setSkipTestIdentifiers:testsToSkip];
+    [bundle setEstimatedExecutionTime:splitExecutionTime];
+
+    return bundle;
 }
 
 @end

--- a/bluepill/src/BPRunner.h
+++ b/bluepill/src/BPRunner.h
@@ -35,8 +35,7 @@
  * @return An NSTask ready to be executed via [task launch] or nil in failure.
  *
  */
-
-- (NSTask *)newTaskWithBundle:(NSArray *)bundle
+- (NSTask *)newTaskWithBundle:(BPXCTestFile *)bundle
                     andNumber:(NSUInteger)number
                     andDevice:(NSString *)deviceID
            andCompletionBlock:(void (^)(NSTask * ))block;

--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -185,7 +185,7 @@ maxprocs(void)
     NSUInteger numSims = [self.config.numSims intValue];
     [BPUtils printInfo:INFO withString:@"This is Bluepill %s", [BPUtils version]];
     NSError *error;
-    NSMutableArray *bundles = [BPPacker packTests:xcTestFiles configuration:self.config andError:&error];
+    NSMutableArray<BPXCTestFile *> *bundles = [[BPPacker packTests:xcTestFiles configuration:self.config andError:&error] mutableCopy];
     if (!bundles || bundles.count == 0) {
         [BPUtils printInfo:ERROR withString:@"Packing failed: %@", [error localizedDescription]];
         return 1;
@@ -204,7 +204,7 @@ maxprocs(void)
     }
     [BPUtils printInfo:INFO withString:@"Running with %lu %s.",
      (unsigned long)numSims, (numSims > 1) ? "parallel simulators" : "simulator"];
-    NSArray *copyBundles = [NSMutableArray arrayWithArray:bundles];
+    NSArray *copyBundles = [bundles copy];
     for (int i = 1; i < [self.config.repeatTestsCount integerValue]; i++) {
         [bundles addObjectsFromArray:copyBundles];
     }

--- a/bp/src/BPUtils.h
+++ b/bp/src/BPUtils.h
@@ -15,6 +15,7 @@ _a < _b ? _a : _b; \
 })
 
 #import <Foundation/Foundation.h>
+#import "bp/src/BPXCTestFile.h"
 
 typedef NS_ENUM(int, BPKind) {
     PASSED,
@@ -170,5 +171,36 @@ typedef BOOL (^BPRunBlock)(void);
  * @return a dictionary with the mappings
  */
 + (NSDictionary *)loadSimpleJsonFile:(NSString *)filePath withError:(NSError **)errPtr;
+
+/*!
+ * @discussion Get total time from config.
+ * @param config The configuration file for this bluepill-runner
+ * @param testTimes Mapping of a test name to it's estimated execution time
+ * @param xcTestFiles An NSArray of BPXCTestFile's to pack
+ * @return The total time to run all the tests
+ */
++ (double)getTotalTimeWithConfig:(BPConfiguration *)config
+                       testTimes:(NSDictionary<NSString *,NSNumber *> *)testTimes
+                  andXCTestFiles:(NSArray<BPXCTestFile *> *)xcTestFiles;
+
+/*!
+ * @discussion Get a set of tests to run by file path.
+ * @param config The configuration file for this bluepill-runner
+ * @param xcTestFiles An NSArray of BPXCTestFile's to pack
+ * @return A dictionary of file path to set of tests mapping
+ */
++ (NSDictionary<NSString *, NSSet *> *)getTestsToRunByFilePathWithConfig:(BPConfiguration *)config
+                                                          andXCTestFiles:(NSArray<BPXCTestFile *> *)xcTestFiles;
+
+/*!
+ * @discussion Get test estimates by file path.
+ * @param config The configuration file for this bluepill-runner
+ * @param testTimes Mapping of a test name to it's estimated execution time
+ * @param xcTestFiles An NSArray of BPXCTestFile's to pack
+ * @return A dictionary of file patn to total time estimate mapping
+ */
++ (NSDictionary<NSString *,NSNumber *> *)getTestEstimatesByFilePathWithConfig:(BPConfiguration *)config
+                                                                    testTimes:(NSDictionary<NSString *,NSNumber *> *)testTimes
+                                                               andXCTestFiles:(NSArray<BPXCTestFile *> *)xcTestFiles;
 
 @end


### PR DESCRIPTION
Often test bundles that take too long to execute become long pole or bottleneck holding up the Bluepill completion for longer than what is ideally needed. So, splitting the test bundles based on the time estimates of all tests in each split could increase the concurrency, re-gain the lost concurrency opportunities and complete the testing as quickly as possible.

The splitting strategy here is to make sure no single bundle takes longer than `the time taken by all bundles divided by the maximum number of concurrent simulators allowed`.

Please review. \cc @ob, @chenxiao0228 