### PR TITLE
[ISSUE-384] Pass simulator preferences file when clone simulator feature is enabled

### DIFF
--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -223,6 +223,10 @@
                 completion(error);
             });
         } else {
+            if (__self.config.simulatorPreferencesFile) {
+                [__self copySimulatorPreferencesFile:__self.config.simulatorPreferencesFile];
+            }
+
             dispatch_async(dispatch_get_main_queue(), ^{
                 [__self bootWithCompletion:^(NSError *error) {
                     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fixing a bug where the simulator preferences file was not being passed in the clone simulator code path. \cc @rahul-malik @ob 