### PR TITLE
Supporting tests and app hosts in subfolders

### DIFF
--- a/bptestrunner/bluepill_batch_test.bzl
+++ b/bptestrunner/bluepill_batch_test.bzl
@@ -20,11 +20,11 @@ def _bluepill_batch_test_impl(ctx):
         test_host = test_info.test_host
         test_bundle = test_info.test_bundle
         if test_bundle:
-            test_bundle_paths.append("\"{}\"".format(test_bundle.basename))
+            test_bundle_paths.append("\"{}\"".format(test_bundle.short_path))
             runfiles.append(test_bundle)
 
         if test_host and test_host not in runfiles:
-            test_host_paths.append("\"{}\"".format(test_host.basename))
+            test_host_paths.append("\"{}\"".format(test_host.short_path))
             runfiles.append(test_host)
 
         #test_plan


### PR DESCRIPTION
If the test or app host is in subfolders, we are not able to find the generated zip/ipa files. Using short_path instead of basename would resolve the issue.