### PR TITLE
Xcode 11.3 support

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 11.2
-        run: sudo xcode-select -s /Applications/Xcode_11.2.app
+      - name: Select Xcode 11.3
+        run: sudo xcode-select -s /Applications/Xcode_11.3.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests
 
@@ -22,8 +22,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 11.2
-        run: sudo xcode-select -s /Applications/Xcode_11.2.app
+      - name: Select Xcode 11.3
+        run: sudo xcode-select -s /Applications/Xcode_11.3.app
       - name: Run BP tests
         run: ./scripts/bluepill.sh runner_tests
       - name: Build and Package

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
     # actions/checkout@v2 but we use the sha because tags can be rewritten in git
     - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-    - name: Select Xcode 11.2
-      run: sudo xcode-select -s /Applications/Xcode_11.2.app
+    - name: Select Xcode 11.3
+      run: sudo xcode-select -s /Applications/Xcode_11.3.app
     - name: Run Bluepill tests
       run: ./scripts/bluepill.sh instance_tests
 
@@ -27,8 +27,8 @@ jobs:
     steps:
     # actions/checkout@v2 but we use the sha because tags can be rewritten in git
     - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-    - name: Select Xcode 11.2
-      run: sudo xcode-select -s /Applications/Xcode_11.2.app
+    - name: Select Xcode 11.3
+      run: sudo xcode-select -s /Applications/Xcode_11.3.app
     - name: Run BP tests
       run: ./scripts/bluepill.sh runner_tests
     - name: Build and Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     # actions/checkout@v2 but we use the sha because tags can be rewritten in git
     - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-    - name: Select Xcode 11.2
-      run: sudo xcode-select -s /Applications/Xcode_11.2.app
+    - name: Select Xcode 11.3
+      run: sudo xcode-select -s /Applications/Xcode_11.3.app
     - name: Run Bluepill tests
       run: ./scripts/bluepill.sh instance_tests
 
@@ -28,8 +28,8 @@ jobs:
     - name: Report event trigger data
       run: |
         echo "Event ${{ github.event_name }}, ref: ${{ github.ref }}"
-    - name: Select Xcode 11.2
-      run: sudo xcode-select -s /Applications/Xcode_11.2.app
+    - name: Select Xcode 11.3
+      run: sudo xcode-select -s /Applications/Xcode_11.3.app
     - name: Run Bluepill tests
       run: ./scripts/bluepill.sh runner_tests
     - name: Build Bluepill

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A full list supported options are listed here.
 
 ## Requirements
 
-Bluepill only works with **Xcode 11.2**. If you're looking for old Xcode support, please check out the other branches:
+Bluepill only works with **Xcode 11.3**. If you're looking for old Xcode support, please check out the other branches:
 
 * [Xcode-8](https://github.com/linkedin/bluepill/tree/xcode8)
 * [Xcode-9.0](https://github.com/linkedin/bluepill/tree/xcode-9.0)
@@ -108,6 +108,7 @@ Bluepill only works with **Xcode 11.2**. If you're looking for old Xcode support
 * [Xcode-10.3](https://github.com/linkedin/bluepill/tree/xcode-10.3)
 * [Xcode-11.0](https://github.com/linkedin/bluepill/tree/xcode-11.0)
 * [Xcode-11.1](https://github.com/linkedin/bluepill/tree/xcode-11.1)
+* [Xcode-11.2](https://github.com/linkedin/bluepill/tree/xcode-11.2)
 
 ## Acknowledgement
 

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -131,8 +131,8 @@
     config.numSims = @2;
     config.testBundlePath = nil;
     config.testRunnerAppPath = nil;
-    NSString *runtime = [[NSString stringWithUTF8String:BP_DEFAULT_RUNTIME] stringByReplacingOccurrencesOfString:@"iOS " withString:@""];
-    NSString *xcTestRunFile = [NSString stringWithFormat:@"Build/Products/BPSampleApp_iphonesimulator%@-x86_64.xctestrun", runtime];
+    NSString *baseSDK = [[NSString stringWithUTF8String:BP_DEFAULT_BASE_SDK] stringByReplacingOccurrencesOfString:@"iOS " withString:@""];
+    NSString *xcTestRunFile = [NSString stringWithFormat:@"Build/Products/BPSampleApp_iphonesimulator%@-x86_64.xctestrun", baseSDK];
     config.xcTestRunPath = [[[BPTestHelper derivedDataPath] stringByDeletingLastPathComponent] stringByAppendingPathComponent:xcTestRunFile];
     NSError *err;
     [config validateConfigWithError:&err];

--- a/bp/src/BPConstants.h
+++ b/bp/src/BPConstants.h
@@ -9,14 +9,16 @@
 
 #import <Foundation/Foundation.h>
 
-#define BP_DEFAULT_RUNTIME "iOS 13.2"
+#pragma mark - Version Constants
+#define BP_DEFAULT_XCODE_VERSION "11.3"
+#define BP_DEFAULT_RUNTIME "iOS 13.3"
+#define BP_DEFAULT_BASE_SDK "13.2"
+
 #define BP_DEFAULT_DEVICE_TYPE "iPhone 8"
-#define BP_TM_PROTOCOL_VERSION 17
+
 #define BP_DAEMON_PROTOCOL_VERSION 26
-#define BP_DEFAULT_XCODE_VERSION "11.2"
 #define BP_MAX_PROCESSES_PERCENT 0.75
 #define BP_TM_PROTOCOL_VERSION 17
-
 
 extern NSString * const kCFBundleIdentifier;
 extern NSString * const kOptionsArgumentsKey;


### PR DESCRIPTION
Since Xcode 11.3 is packed with SDK 13.2, we need another constant to
  indicate base SDK.