### PR TITLE
Added a few more tests to mock test failure scenarios and fixed a few final Exit Status issues 

### DIFF
--- a/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
+++ b/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
@@ -48,6 +48,7 @@
         return;
     }
     NSString *currentPlan = setsOfPlans[index];
+    currentPlan = [currentPlan stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     NSArray *array = [currentPlan componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     if (attempt > [array count]) {
         NSLog(@"Passing on attempt#%ld, by default, as there is no action defined in the execution plan", (long)attempt);

--- a/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
+++ b/BPSampleApp/BPSampleAppHangingTests/BPSampleAppHangingTests.m
@@ -15,6 +15,20 @@
 
 @implementation BPSampleAppHangingTests
 
+long attemptFromSimulatorVersionInfo(NSString *simulatorVersionInfo) {
+    // simulatorVersionInfo is something like
+    // CoreSimulator 587.35 - Device: BP93497-2-2 (7AB3D528-5473-401A-B23E-2E2E86C73861) - Runtime: iOS 12.2 (16E226) - DeviceType: iPhone 7
+    NSArray<NSString *> *parts = [simulatorVersionInfo componentsSeparatedByString:@" - "];
+    NSString *deviceString = parts[1];
+    // Device: BP93497-2-2 (7AB3D528-5473-401A-B23E-2E2E86C73861)
+    parts = [deviceString componentsSeparatedByString:@" "];
+    NSString *device = parts[1];
+    // BP93497-2-2
+    parts = [device componentsSeparatedByString:@"-"];
+    NSString *attempt = parts[1];
+    return [attempt longLongValue];
+}
+
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -26,8 +40,51 @@
     [super tearDown];
 }
 
-- (void)testAppHanging {
-    while(TRUE){};
+- (void)testSimpleTest {
+    XCTAssert(YES);
 }
 
+- (void)testBasedOnExecutionPlan {
+    NSDictionary *env = [[NSProcessInfo processInfo] environment];
+    NSString *simulatorVersionInfo = [env objectForKey:@"SIMULATOR_VERSION_INFO"];
+    long attempt = attemptFromSimulatorVersionInfo(simulatorVersionInfo);
+    NSString *executionPlan = [env objectForKey:@"_BP_TEST_EXECUTION_PLAN"];
+    if (!executionPlan) {
+        NSLog(@"No execution plan found in attempt#%ld. Failing the test.", attempt);
+        XCTAssert(NO);
+        return;
+    }
+    NSLog(@"Received execution plan %@ on attempt#%ld for this test.", executionPlan, attempt);
+
+    NSArray *array = [executionPlan componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (attempt > [array count]) {
+        NSLog(@"Passing on attempt#%ld, by default, as there is no action defined in the execution plan", (long)attempt);
+        XCTAssert(YES);
+        return;
+    }
+    NSString *action = array[attempt - 1];
+    if ([action isEqualToString:@"TIMEOUT"]) {
+        NSLog(@"Entering into an infinite loop on attempt#%ld to timeout as per the execution plan", (long)attempt);
+        while(1) {
+        }
+        return;
+    } else if ([action isEqualToString:@"PASS"]) {
+        NSLog(@"Passing on attempt#%ld based on execution plan", (long)attempt);
+        XCTAssert(YES);
+        return;
+    } else if ([action isEqualToString:@"FAIL"]) {
+        NSLog(@"Failing on attempt#%ld based on execution plan", (long)attempt);
+        XCTAssert(NO);
+        return;
+    } else if ([action isEqualToString:@"CRASH"]) {
+        NSLog(@"Crashing on attempt#%ld based on execution plan", (long)attempt);
+        // ok, let's crash and burn
+        int *pointer = nil;
+        *pointer = 1;
+        return;
+    }
+    NSLog(@"Failing on attempt#%ld as an unidentified action is encountered in the execution plan", (long)attempt);
+    XCTAssert(NO);
+    return;
+}
 @end

--- a/README.md
+++ b/README.md
@@ -54,39 +54,60 @@ $ bluepill -c config.json
 A full list supported options are listed here.
 
 
-|   Config Arguments     | Command Line Arguments | Explanation                                                                        | Required | Default value    |
-|:----------------------:|:----------------------:|------------------------------------------------------------------------------------|:--------:|:----------------:|
-|          `app`         |           -a           | The path to the host application to execute (your .app)                            |     N    | n/a              |
-|    `xctestrun-path`    |                        | The path to the `.xctestrun` file that xcode leaves when you `build-for-testing`.  |     Y    | n/a              |
-|      `output-dir`      |           -o           | Directory where to put output log files (bluepill only)                            |     Y    | n/a              |
-|         config         |           -c           | Read options from the specified configuration file instead of the command line     |     N    | n/a              |
-|         device         |           -d           | On which device to run the app.                                                    |     N    | iPhone 6         |
-|         exclude        |           -x           | Exclude a testcase in the set of tests to run  (takes priority over `include`).    |     N    | empty            |
-|        headless        |           -H           | Run in headless mode (no GUI).                                                     |     N    | off              |
-|        clone-simulator        |           -L           | Spawn simulator by clone from simulator template.                                                     |     N    | off              |
-|        xcode-path      |           -X           | Path to xcode.                                                                     |     N    | xcode-select -p  |
-|         include        |           -i           | Include a testcase in the set of tests to run (unless specified in `exclude`).     |     N    | all tests        |
-|       list-tests       |           -l           | Only list tests in bundle                                                          |     N    | false            |
-|        num-sims        |           -n           | Number of simulators to run in parallel. (bluepill only)                           |     N    | 4                |
-|      printf-config     |           -P           | Print a configuration file suitable for passing back using the `-c` option.        |     N    | n/a              |
-|      error-retries     |           -R           | Number of times to recover from simulator/app crashing/hanging and continue running|     N    | 5                |
-|    failure-tolerance   |           -f           | Number of times to retry on test failures                                          |     N    | 0                |
-|    only-retry-failed   |           -F           | When `failure-tolerance` > 0, only retry tests that failed                         |     N    | false            |
-|         runtime        |           -r           | What runtime to use.                                                               |     N    | iOS 11.1         |
-|      stuck-timeout     |           -S           | Timeout in seconds for a test that seems stuck (no output).                        |     N    | 300s             |
-|      test-timeout      |           -T           | Timeout in seconds for a test that is producing output.                            |     N    | 300s             |
-|    test-bundle-path    |           -t           | The path to the test bundle to execute (single .xctest).                           |     N    | n/a              |
-| additional-unit-xctests|           n/a          | Additional XCTest bundles that is not Plugin folder                                |     N    | n/a              |
-|  additional-ui-xctests |           n/a          | Additional XCTUITest bundles that is not Plugin folder                             |     N    | n/a              |
-|      repeat-count      |           -C           | Number of times we'll run the entire test suite (used for load testing).           |     N    | 1                |
-|        no-split        |           -N           | Test bundles you don't want to be packed into different groups to run in parallel. |     N    | n/a              |
-|         quiet          |           -q           | Turn off all output except fatal errors.                                           |     N    | YES              |
-|       diagnostics      |           n/a          | Enable collection of diagnostics in outputDir in case of test failures             |     N    | NO               |
-|          help          |           -h           | Help.                                                                              |     N    | n/a              |
-|     runner-app-path    |           -u           | The test runner for UI tests.                                                      |     N    | n/a              |
-| screenshots-directory  |           n/a          | Directory where simulator screenshots for failed ui tests will be stored           |     N    | n/a              |
-|       video-paths      |           -V           | A list of videos that will be saved in the simulators                              |     N    | n/a              |
-|       image-paths      |           -I           | A list of images that will be saved in the simulators                              |     N    | n/a              |
+|   Config Arguments     | Command Line Arguments | Explanation                                                                         | Required | Default value    |
+|:----------------------:|:----------------------:|-------------------------------------------------------------------------------------|:--------:|:----------------:|
+|          app           |           -a           | The path to the host application to execute (your `.app`)                           |     N    | n/a              |
+|     xctestrun-path     |                        | The path to the `.xctestrun` file that xcode leaves when you `build-for-testing`.   |     Y    | n/a              |
+|       output-dir       |           -o           | Directory where to put output log files. **(bluepill only)**                        |     Y    | n/a              |
+|         config         |           -c           | Read options from the specified configuration file instead of the command line.     |     N    | n/a              |
+|         device         |           -d           | On which device to run the app.                                                     |     N    | iPhone 8         |
+|         exclude        |           -x           | Exclude a testcase in the set of tests to run  (takes priority over `include`).     |     N    | empty            |
+|        headless        |           -H           | Run in headless mode (no GUI).                                                      |     N    | off              |
+|        clone-simulator |           -L           | Spawn simulator by clone from simulator template.                                   |     N    | off              |
+|        xcode-path      |           -X           | Path to xcode.                                                                      |     N    | xcode-select -p  |
+|         include        |           -i           | Include a testcase in the set of tests to run (unless specified in `exclude`).      |     N    | all tests        |
+|       list-tests       |           -l           | Only list tests and exit without executing tests.                                   |     N    | false            |
+|        num-sims        |           -n           | Number of simulators to run in parallel. **(bluepill only)**                        |     N    | 4                |
+|      printf-config     |           -P           | Print a configuration file suitable for passing back using the `-c` option.         |     N    | n/a              |
+|      error-retries     |           -R           | Number of times to recover from simulator/app crashing/hanging and continue running.|     N    | 4                |
+|    failure-tolerance   |           -f           | Number of times to retry on test failures                                           |     N    | 0                |
+|    only-retry-failed   |           -F           | Only retry failed tests instead of all. Also retry test that timed-out/crashed.     |     N    | false            |
+|         runtime        |           -r           | What runtime to use.                                                                |     N    | iOS 13.3         |
+|      stuck-timeout     |           -S           | Timeout in seconds for a test that seems stuck (no output).                         |     N    | 300s             |
+|      test-timeout      |           -T           | Timeout in seconds for a test that is producing output.                             |     N    | 300s             |
+|    test-bundle-path    |           -t           | The path to the test bundle to execute (single `.xctest`).                          |     N    | n/a              |
+| additional-unit-xctests|           n/a          | Additional XCTest bundles that is not Plugin folder                                 |     N    | n/a              |
+|  additional-ui-xctests |           n/a          | Additional XCTUITest bundles that is not Plugin folder                              |     N    | n/a              |
+|      repeat-count      |           -C           | Number of times we'll run the entire test suite (used for load testing).            |     N    | 1                |
+|        no-split        |           -N           | Test bundles you don't want to be packed into different groups to run in parallel.  |     N    | n/a              |
+|         quiet          |           -q           | Turn off all output except fatal errors.                                            |     N    | YES              |
+|       diagnostics      |           n/a          | Enable collection of diagnostics in output directory in case of test failures.      |     N    | NO               |
+|          help          |           -h           | Help.                                                                               |     N    | n/a              |
+|     runner-app-path    |           -u           | The test runner for UI tests.                                                       |     N    | n/a              |
+| screenshots-directory  |           n/a          | Directory where simulator screenshots for failed ui tests will be stored.           |     N    | n/a              |
+|       video-paths      |           -V           | A list of videos that will be saved in the simulators.                              |     N    | n/a              |
+|       image-paths      |           -I           | A list of images that will be saved in the simulators.                              |     N    | n/a              |
+
+## Exit Status
+
+Here is a list of Bluepill exit codes. If a Bluepill execution has multiple exit codes from same or different test bundles, the final exit code is a combination of all exit codes. Note that app crashes are fatal even if the test passes on retry.
+
+```shell
+  BPExitStatusAllTestsPassed          = 0,
+  BPExitStatusTestsFailed             = 1 << 0,
+  BPExitStatusSimulatorCreationFailed = 1 << 1,
+  BPExitStatusInstallAppFailed        = 1 << 2,
+  BPExitStatusInterrupted             = 1 << 3,
+  BPExitStatusSimulatorCrashed        = 1 << 4,
+  BPExitStatusLaunchAppFailed         = 1 << 5,
+  BPExitStatusTestTimeout             = 1 << 6,
+  BPExitStatusAppCrashed              = 1 << 7,
+  BPExitStatusSimulatorDeleted        = 1 << 8,
+  BPExitStatusUninstallAppFailed      = 1 << 9,
+  BPExitStatusSimulatorReuseFailed    = 1 << 10
+```
+**Note:** Please refer to `bp/src/BPExitStatus.h` for the latest/exact exit codes.
+
 
 ## Demo
 
@@ -139,7 +160,7 @@ If you're using [Bitrise.io](https://bitrise.io) as your CI/CD, you can start us
 
   Latest [release](https://github.com/linkedin/bluepill/releases/).
 
-- How to test Bluepill in Xcode
+- How to test Bluepill in Xcode?
 
   Select BPSampleApp scheme and build it first. Then you can switch back to `bluepill` or `bluepill-cli` scheme to run their tests.
 

--- a/bluepill/tests/BPPackerTests.m
+++ b/bluepill/tests/BPPackerTests.m
@@ -187,7 +187,7 @@
     // Make sure we don't split when we don't want to
     self.config.numSims = @4;
     self.config.noSplit = @[@"BPSampleAppTests"];
-    bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];// withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
+    bundles = [BPPacker packTests:app.testBundles configuration:self.config andError:nil];  // withNoSplitList:@[@"BPSampleAppTests"] intoBundles:4 andError:nil];
     // When we prevent BPSampleTests from splitting, BPSampleAppFatalErrorTests and BPAppNegativeTests gets split in two
     want = [[want arrayByAddingObject:@"BPSampleAppFatalErrorTests"] sortedArrayUsingSelector:@selector(compare:)];
     XCTAssertEqual(bundles.count, app.testBundles.count + 2);
@@ -195,9 +195,10 @@
     XCTAssertEqual([bundles[0].skipTestIdentifiers count], 0);
     XCTAssertEqual([bundles[1].skipTestIdentifiers count], 0);
     XCTAssertEqual([bundles[2].skipTestIdentifiers count], 0);
-    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 2);
-    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 3);
+    XCTAssertEqual([bundles[3].skipTestIdentifiers count], 1);
+    XCTAssertEqual([bundles[4].skipTestIdentifiers count], 4);
     XCTAssertEqual([bundles[5].skipTestIdentifiers count], 1);
+    XCTAssertEqual([bundles[6].skipTestIdentifiers count], 4);
 
     self.config.numSims = @4;
     self.config.noSplit = nil;
@@ -209,14 +210,17 @@
     long testsPerBundle = [allTests count] / numSims;
     long skipTestsPerBundle = 0;
     long skipTestsInFinalBundle = 0;
+    long testCount = 0;
     for (int i = 0; i < bundles.count; ++i) {
         skipTestsPerBundle = ([[bundles[i] allTestCases] count] - testsPerBundle);
-        skipTestsInFinalBundle = testsPerBundle * (numSims - 1);
         if (i < 4) {
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], 0);
+            testCount += [[bundles[i] allTestCases] count];
         } else if (i < bundles.count-1) {
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], skipTestsPerBundle);
+            testCount += testsPerBundle;
         } else {  /* last bundle */
+            skipTestsInFinalBundle = [[bundles[i] allTestCases] count] - ([allTests count] - testCount);
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], skipTestsInFinalBundle);
         }
     }
@@ -231,15 +235,19 @@
 
     numSims = [self.config.numSims integerValue];
     testsPerBundle = [allTests count] / numSims;
+    testCount = 0;
     for (int i = 0; i < bundles.count; ++i) {
         skipTestsPerBundle = ([[bundles[i] allTestCases] count] - testsPerBundle);
-        skipTestsInFinalBundle = testsPerBundle * (numSims - 1);
         if (i < 4) {
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], 0);
+            testCount += [[bundles[i] allTestCases] count];
         } else if (i < bundles.count-1) {
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], skipTestsPerBundle);
+            testCount += testsPerBundle;
         } else {  /* last bundle */
+            skipTestsInFinalBundle = [[bundles[i] allTestCases] count] - ([allTests count] - testCount);
             XCTAssertEqual([bundles[i].skipTestIdentifiers count], skipTestsInFinalBundle);
+
         }
     }
 

--- a/bp/bp.xcodeproj/xcshareddata/xcschemes/bp-tests.xcscheme
+++ b/bp/bp.xcodeproj/xcshareddata/xcschemes/bp-tests.xcscheme
@@ -62,12 +62,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "BluepillTests/testAppThatCrashesOnLaunch">
-               </Test>
-               <Test
-                  Identifier = "BluepillTests/testAppThatHangsOnLaunch">
-               </Test>
-               <Test
                   Identifier = "BluepillTests/testReportWithFailingTestsSet">
                </Test>
                <Test
@@ -75,12 +69,6 @@
                </Test>
                <Test
                   Identifier = "BluepillTests/testRetryWithFailingTestsSet">
-               </Test>
-               <Test
-                  Identifier = "BluepillTests/testRunningAndIgnoringCertainTestCases">
-               </Test>
-               <Test
-                  Identifier = "BluepillTests/testRunningOnlyCertainTestcases">
                </Test>
                <Test
                   Identifier = "BluepillTests/testVoyager">

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -116,6 +116,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic) BOOL testing_HangAppOnLaunch;
 @property (nonatomic) BOOL testing_NoAppWillRun;
 @property (nonatomic) NSNumber *testing_crashOnAttempt;
+@property (nonatomic, strong) NSString *testing_ExecutionPlan;
 
 // Generated fields
 @property (nonatomic, strong) NSString *xcodePath;

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -18,10 +18,10 @@
 
 
 typedef NS_OPTIONS(NSUInteger, BPOptionType) {
-    BP_VALUE = 1, // Single value
-    BP_LIST = 1 << 1, // List value
-    BP_PATH = 1 << 2, // Single value, CWD will be prepended
-    BP_BOOL = 1 << 3, // Boolean value
+    BP_VALUE   = 1 << 0, // Single value
+    BP_LIST    = 1 << 1, // List value
+    BP_PATH    = 1 << 2, // Single value, CWD will be prepended
+    BP_BOOL    = 1 << 3, // Boolean value
     BP_INTEGER = 1 << 4, // Integer value
 };
 
@@ -103,9 +103,9 @@ struct BPOptions {
     {'q', "quiet", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "quiet",
         "Turn off all output except fatal errors."},
     {'F', "only-retry-failed", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "onlyRetryFailed",
-        "If `failure-`tolerance` is > 0, only retry tests that failed."},
+        "Only retry failed tests instead of all. Also retry test that timed-out/crashed. Note that app crashes are fatal even if the test passes on retry."},
     {'l', "list-tests", BP_MASTER, NO, NO, no_argument, NULL, BP_VALUE | BP_BOOL, "listTestsOnly",
-        "Only list tests in bundle"},
+        "Only list tests and exit without executing tests."},
     {'v', "verbose", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "verboseLogging",
         "Enable verbose logging"},
     {'k', "keep-individual-test-reports", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepIndividualTestReports",

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -371,6 +371,7 @@ static NSUUID *sessionID;
     newConfig.testing_HangAppOnLaunch = self.testing_HangAppOnLaunch;
     newConfig.testing_NoAppWillRun = self.testing_NoAppWillRun;
     newConfig.testing_crashOnAttempt = self.testing_crashOnAttempt;
+    newConfig.testing_ExecutionPlan = self.testing_ExecutionPlan;
     newConfig.xcTestRunPath = self.xcTestRunPath;
     newConfig.testPlanPath = self.testPlanPath;
     newConfig.xcTestRunDict = self.xcTestRunDict;

--- a/bp/src/BPExitStatus.h
+++ b/bp/src/BPExitStatus.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, BPExitStatus) {
-    BPExitStatusTestsAllPassed          = 0,
+    BPExitStatusAllTestsPassed          = 0,
     BPExitStatusTestsFailed             = 1 << 0,
     BPExitStatusSimulatorCreationFailed = 1 << 1,
     BPExitStatusInstallAppFailed        = 1 << 2,

--- a/bp/src/BPExitStatus.h
+++ b/bp/src/BPExitStatus.h
@@ -10,18 +10,18 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, BPExitStatus) {
-    BPExitStatusTestsAllPassed = 0,
-    BPExitStatusTestsFailed = 1,
-    BPExitStatusSimulatorCreationFailed = 2,
-    BPExitStatusSimulatorCrashed = 3,
-    BPExitStatusInstallAppFailed = 4,
-    BPExitStatusLaunchAppFailed = 5,
-    BPExitStatusTestTimeout = 6,
-    BPExitStatusAppCrashed = 7,
-    BPExitStatusInterrupted = 8,
-    BPExitStatusSimulatorDeleted = 9,
-    BPExitStatusUninstallAppFailed = 10,
-    BPExitStatusSimulatorReuseFailed = 11,
+    BPExitStatusTestsAllPassed          = 0,
+    BPExitStatusTestsFailed             = 1 << 0,
+    BPExitStatusSimulatorCreationFailed = 1 << 1,
+    BPExitStatusInstallAppFailed        = 1 << 2,
+    BPExitStatusInterrupted             = 1 << 3,
+    BPExitStatusSimulatorCrashed        = 1 << 4,
+    BPExitStatusLaunchAppFailed         = 1 << 5,
+    BPExitStatusTestTimeout             = 1 << 6,
+    BPExitStatusAppCrashed              = 1 << 7,
+    BPExitStatusSimulatorDeleted        = 1 << 8,
+    BPExitStatusUninstallAppFailed      = 1 << 9,
+    BPExitStatusSimulatorReuseFailed    = 1 << 10
 };
 
 @protocol BPExitStatusProtocol <NSObject>

--- a/bp/src/BPExitStatus.m
+++ b/bp/src/BPExitStatus.m
@@ -13,8 +13,7 @@
 
 @implementation BPExitStatusHelper
 
-// Exit status to string
-+ (NSString *)stringFromExitStatus:(BPExitStatus)exitStatus {
++ (NSString *)simpleExitStatus:(BPExitStatus)exitStatus {
     switch (exitStatus) {
         case BPExitStatusTestsAllPassed:
             return @"BPExitStatusTestsAllPassed";
@@ -22,6 +21,10 @@
             return @"BPExitStatusTestsFailed";
         case BPExitStatusSimulatorCreationFailed:
             return @"BPExitStatusSimulatorCreationFailed";
+        case BPExitStatusInstallAppFailed:
+            return @"BPExitStatusInstallAppFailed";
+        case BPExitStatusInterrupted:
+            return @"BPExitStatusInterrupted";
         case BPExitStatusSimulatorCrashed:
             return @"BPExitStatusSimulatorCrashed";
         case BPExitStatusLaunchAppFailed:
@@ -30,17 +33,30 @@
             return @"BPExitStatusTestTimeout";
         case BPExitStatusAppCrashed:
             return @"BPExitStatusAppCrashed";
-        case BPExitStatusInstallAppFailed:
-            return @"BPExitStatusInstallAppFailed";
-        case BPExitStatusInterrupted:
-            return @"BPExitStatusInterrupted";
         case BPExitStatusSimulatorDeleted:
             return @"BPExitStatusSimulatorDeleted";
+        case BPExitStatusUninstallAppFailed:
+            return @"BPExitStatusUninstallAppFailed";
         case BPExitStatusSimulatorReuseFailed:
             return @"BPExitStatusSimulatorReuseFailed";
         default:
-            return @"UNKNOWN_BPEXITSTATUS";
+            return [NSString stringWithFormat:@"UNKNOWN_BPEXITSTATUS - %ld", (long)exitStatus];
     }
+}
+
+// Exit status to string
++ (NSString *)stringFromExitStatus:(BPExitStatus)exitStatus {
+    if (exitStatus == BPExitStatusTestsAllPassed)
+        return @"BPExitStatusTestsAllPassed";
+
+    NSString *exitStatusString = @"";
+    while (exitStatus > 0) {
+        BPExitStatus prevExitStatus = exitStatus;
+        exitStatus = exitStatus & (exitStatus - 1);
+        exitStatusString = [exitStatusString stringByAppendingFormat:@"%@ ", [self simpleExitStatus:(prevExitStatus - exitStatus)]];
+    }
+
+    return [exitStatusString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 
 @end

--- a/bp/src/BPExitStatus.m
+++ b/bp/src/BPExitStatus.m
@@ -15,8 +15,8 @@
 
 + (NSString *)simpleExitStatus:(BPExitStatus)exitStatus {
     switch (exitStatus) {
-        case BPExitStatusTestsAllPassed:
-            return @"BPExitStatusTestsAllPassed";
+        case BPExitStatusAllTestsPassed:
+            return @"BPExitStatusAllTestsPassed";
         case BPExitStatusTestsFailed:
             return @"BPExitStatusTestsFailed";
         case BPExitStatusSimulatorCreationFailed:
@@ -46,8 +46,8 @@
 
 // Exit status to string
 + (NSString *)stringFromExitStatus:(BPExitStatus)exitStatus {
-    if (exitStatus == BPExitStatusTestsAllPassed)
-        return @"BPExitStatusTestsAllPassed";
+    if (exitStatus == BPExitStatusAllTestsPassed)
+        return @"BPExitStatusAllTestsPassed";
 
     NSString *exitStatusString = @"";
     while (exitStatus > 0) {

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -498,6 +498,9 @@
     if (self.config.testing_HangAppOnLaunch) {
         mutableAppLaunchEnv[@"_BP_TEST_HANG_ON_LAUNCH"] = @"YES";
     }
+    if (self.config.testing_ExecutionPlan) {
+        mutableAppLaunchEnv[@"_BP_TEST_EXECUTION_PLAN"] = self.config.testing_ExecutionPlan;
+    }
     appLaunchEnvironment = [mutableAppLaunchEnv copy];
     NSDictionary *options = @{
                               kOptionsArgumentsKey: argsAndEnv[@"args"],

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -625,7 +625,7 @@
 - (BOOL)checkFinished {
     if ([self.monitor isExecutionComplete]) {
         switch ([self.monitor exitStatus]) {
-            case BPExitStatusTestsAllPassed:
+            case BPExitStatusAllTestsPassed:
             case BPExitStatusTestsFailed:
                 return YES;
             default:

--- a/bp/src/BPStats.m
+++ b/bp/src/BPStats.m
@@ -240,7 +240,7 @@
 }
 
 - (NSString *)resultToCname:(NSString *)result {
-    if ([result isEqualToString:@"PASSED"] || [result isEqualToString:@"BPExitStatusTestsAllPassed"]) {
+    if ([result isEqualToString:@"PASSED"] || [result isEqualToString:@"BPExitStatusAllTestsPassed"]) {
         return @"good";
     } else if ([result isEqualToString:@"FAILED"] || [result isEqualToString:@"BPExitStatusTestsFailed"]) {
         return @"bad";

--- a/bp/src/BPUtils.m
+++ b/bp/src/BPUtils.m
@@ -379,7 +379,6 @@ static BOOL quiet = NO;
     NSDictionary<NSString *, NSSet *> *testsToRunByFilePath = [BPUtils getTestsToRunByFilePathWithConfig:config
                                                                                           andXCTestFiles:xcTestFiles];
     for(NSString *filePath in testsToRunByFilePath) {
-        NSLog(@"filePath=%@ Tests to run in this filePath=%@", filePath, [testsToRunByFilePath objectForKey:filePath]);
         NSSet *bundleTestsToRun = [testsToRunByFilePath objectForKey:filePath];
         double __block testBundleExecutionTime = 0.0;
         [bundleTestsToRun enumerateObjectsUsingBlock:^(id _Nonnull test, BOOL * _Nonnull stop) {
@@ -419,7 +418,6 @@ static BOOL quiet = NO;
     NSDictionary<NSString *, NSSet *> *testsToRunByFilePath = [BPUtils getTestsToRunByFilePathWithConfig:config
                                                                                           andXCTestFiles:xcTestFiles];
     for(NSString *filePath in testsToRunByFilePath) {
-        NSLog(@"filePath=%@ Tests to run in this filePath=%@", filePath, [testsToRunByFilePath objectForKey:filePath]);
         NSSet *bundleTestsToRun = [testsToRunByFilePath objectForKey:filePath];
         double __block testBundleExecutionTime = 0.0;
         [bundleTestsToRun enumerateObjectsUsingBlock:^(id _Nonnull test, BOOL * _Nonnull stop) {

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -120,11 +120,13 @@ static void onInterrupt(int ignore) {
     // There were test failures. Check if it can be retried.
     if (![self canRetryOnError] || self.failureTolerance <= 0) {
         // If there is no more retries, set the final exitCode to current context's exitCode
-        self.finalExitStatus = self.context.exitStatus | self.context.finalExitStatus;
+        self.finalExitStatus |= self.context.finalExitStatus;
         [BPUtils printInfo:INFO withString:@"%s:%d finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
         self.exitLoop = YES;
         return;
     }
+    // Resetting the failed bit since the test is being retried
+    self.context.finalExitStatus &= ~self.context.exitStatus;
     [self.context.parser cleanup];
     // Otherwise, reduce our failure tolerance count and retry
     self.failureTolerance -= 1;
@@ -155,13 +157,13 @@ static void onInterrupt(int ignore) {
 - (void)recover {
     // If error retry reach to the max, then return
     if (![self canRetryOnError]) {
-        self.finalExitStatus = self.context.exitStatus | self.context.finalExitStatus;
+        self.finalExitStatus |= self.context.finalExitStatus;
         [BPUtils printInfo:INFO withString:@"%s:%d finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
         self.exitLoop = YES;
         [BPUtils printInfo:ERROR withString:@"Too many retries have occurred. Giving up."];
         return;
     }
-    
+
     [self.context.parser cleanup];
     // If we're not retrying only failed tests, we need to get rid of our saved tests, so that we re-execute everything. Recopy config.
     if (self.executionConfigCopy.onlyRetryFailed == NO) {
@@ -169,7 +171,7 @@ static void onInterrupt(int ignore) {
     }
     // Increment the retry count
     self.retries += 1;
-    
+
     // Log some useful information to the log
     [BPUtils printInfo:INFO withString:@"Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:self.context.exitStatus]];
     [BPUtils printInfo:INFO withString:@"Failure Tolerance: %lu", self.failureTolerance];
@@ -183,7 +185,7 @@ static void onInterrupt(int ignore) {
 // Proceed to next test case
 - (void)proceed {
     if (![self canRetryOnError]) {
-        self.finalExitStatus = self.context.exitStatus | self.context.finalExitStatus;
+        self.finalExitStatus |= self.context.finalExitStatus;
         [BPUtils printInfo:INFO withString:@"%s:%d finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
         self.exitLoop = YES;
         [BPUtils printInfo:ERROR withString:@"Too many retries have occurred. Giving up."];
@@ -195,6 +197,7 @@ static void onInterrupt(int ignore) {
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
     self.context.attemptNumber = self.retries + 1; // set the attempt number
     self.context.exitStatus = BPExitStatusTestsAllPassed; // reset exitStatus
+
     [BPUtils printInfo:INFO withString:@"Proceeding to next test"];
     NEXT([self beginWithContext:self.context]);
 }
@@ -578,36 +581,17 @@ static void onInterrupt(int ignore) {
     }
 }
 
-- (BOOL)hasRemainingTestsInContext:(BPExecutionContext *)context {
-    // Make sure we're not doing unnecessary work on the next run.
-    NSMutableSet *testsRemaining = [[NSMutableSet alloc] initWithArray:context.config.allTestCases];
-    NSSet *testsToSkip = [[NSSet alloc] initWithArray:context.config.testCasesToSkip];
-    [testsRemaining minusSet:testsToSkip];
-    return ([testsRemaining count] > 0);
-}
-
 /**
  Scenarios:
- 1. crash/time out and proceed passes -> Crash/Timeout
- 2. crash/time out and retry passes -> AllPass
+ 1. crash and proceed passes -> Crash
+ 2. time out and retry passes -> AllPass
  3. failure and retry passes -> AllPass
  4. happy all pass -> AllPassed
  5. failure and still fails -> TestFailed
  */
 - (void)finishWithContext:(BPExecutionContext *)context {
-
-    // Because BPExitStatusTestsAllPassed is 0, we must check it explicitly against
-    // the run rather than the aggregate bitmask built with finalExitStatus
-
-    if (![self hasRemainingTestsInContext:context] && (context.attemptNumber <= [context.config.errorRetriesCount integerValue])) {
-        [BPUtils printInfo:INFO withString:@"No more tests to run."];
-        [BPUtils printInfo:INFO withString:@"%s:%d finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
-        // TODO: Temporarily disabling the fix from PR#338 while the issue is being investigated
-        // self.finalExitStatus = context.exitStatus;
-        self.finalExitStatus = context.finalExitStatus | context.exitStatus;
-        self.exitLoop = YES;
-        return;
-    }
+    context.finalExitStatus |= context.exitStatus;
+    [BPUtils printInfo:INFO withString:@"Attempt's Exit Status: %@", [BPExitStatusHelper stringFromExitStatus:context.exitStatus]];
 
     switch (context.exitStatus) {
         // BP exit handler
@@ -615,23 +599,15 @@ static void onInterrupt(int ignore) {
             self.exitLoop = YES;
             return;
 
-        // MARK: Test suite completed
-
         // If there is no test crash/time out, we retry from scratch
         case BPExitStatusTestsFailed:
             NEXT([self retry]);
             return;
 
         case BPExitStatusTestsAllPassed:
-            // Check previous result
-            if (context.finalExitStatus != BPExitStatusTestsAllPassed) {
-                // If there is a test crashed/timed out before, retry from scratch
-                NEXT([self retry]);
-            } else {
-                // If it is a real all pass, exit
-                self.exitLoop = YES;
-                return;
-            }
+            // Time to exit
+            self.finalExitStatus |= BPExitStatusTestsAllPassed;
+            self.exitLoop = YES;
             return;
 
         // Recover from scratch if there is tooling failure.
@@ -645,21 +621,23 @@ static void onInterrupt(int ignore) {
 
         // If it is test hanging or crashing, we set final exit code of current context and proceed.
         case BPExitStatusTestTimeout:
-            context.finalExitStatus = BPExitStatusTestTimeout;
             NEXT([self proceed]);
             return;
+
         case BPExitStatusAppCrashed:
-            context.finalExitStatus = BPExitStatusAppCrashed;
+            // Remember the app crash and report whether a retry passes or not
+            self.finalExitStatus |= BPExitStatusAppCrashed;
             NEXT([self proceed]);
             return;
+
         case BPExitStatusSimulatorDeleted:
         case BPExitStatusSimulatorReuseFailed:
-            self.finalExitStatus = context.exitStatus;
+            self.finalExitStatus |= context.finalExitStatus;
             [BPUtils printInfo:INFO withString:@"%s:%d finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:self.finalExitStatus]];
             self.exitLoop = YES;
             return;
     }
-
+    [BPUtils printInfo:ERROR withString:@"%s:%d YOU SHOULDN'T BE HERE. exitStatus = %@, finalExitStatus = %@", __FILE__, __LINE__, [BPExitStatusHelper stringFromExitStatus:context.exitStatus], [BPExitStatusHelper stringFromExitStatus:context.finalExitStatus]];
 }
 
 // MARK: Helpers

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -621,12 +621,15 @@ static void onInterrupt(int ignore) {
 
         // If it is test hanging or crashing, we set final exit code of current context and proceed.
         case BPExitStatusTestTimeout:
+            if (!self.config.onlyRetryFailed) {
+                self.finalExitStatus |= context.exitStatus;
+            }
             NEXT([self proceed]);
             return;
 
         case BPExitStatusAppCrashed:
             // Remember the app crash and report whether a retry passes or not
-            self.finalExitStatus |= BPExitStatusAppCrashed;
+            self.finalExitStatus |= context.exitStatus;
             NEXT([self proceed]);
             return;
 

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -196,7 +196,7 @@ static void onInterrupt(int ignore) {
     [BPUtils printInfo:INFO withString:@"Failure Tolerance: %lu", self.failureTolerance];
     [BPUtils printInfo:INFO withString:@"Retry count: %lu", self.retries];
     self.context.attemptNumber = self.retries + 1; // set the attempt number
-    self.context.exitStatus = BPExitStatusTestsAllPassed; // reset exitStatus
+    self.context.exitStatus = BPExitStatusAllTestsPassed; // reset exitStatus
 
     [BPUtils printInfo:INFO withString:@"Proceeding to next test"];
     NEXT([self beginWithContext:self.context]);
@@ -505,13 +505,13 @@ static void onInterrupt(int ignore) {
         // If we crashed, we need to retry
         [self deleteSimulatorWithContext:context andStatus:BPExitStatusSimulatorCrashed];
     } else if (self.config.keepSimulator
-               && (context.runner.exitStatus == BPExitStatusTestsAllPassed
+               && (context.runner.exitStatus == BPExitStatusAllTestsPassed
                 || context.runner.exitStatus == BPExitStatusTestsFailed)) {
       context.exitStatus = [context.runner exitStatus];
       NEXT([self finishWithContext:context]);
     } else {
       // If the tests failed, save as much debugging info as we can. XXX: Put this behind a flag
-      if (context.runner.exitStatus != BPExitStatusTestsAllPassed && _config.saveDiagnosticsOnError) {
+      if (context.runner.exitStatus != BPExitStatusAllTestsPassed && _config.saveDiagnosticsOnError) {
         [BPUtils printInfo:INFO withString:@"Saving Diagnostics for Debugging"];
         [BPUtils saveDebuggingDiagnostics:_config.outputDirectory];
       }
@@ -604,9 +604,9 @@ static void onInterrupt(int ignore) {
             NEXT([self retry]);
             return;
 
-        case BPExitStatusTestsAllPassed:
+        case BPExitStatusAllTestsPassed:
             // Time to exit
-            self.finalExitStatus |= BPExitStatusTestsAllPassed;
+            self.finalExitStatus |= BPExitStatusAllTestsPassed;
             self.exitLoop = YES;
             return;
 

--- a/bp/src/SimulatorMonitor.m
+++ b/bp/src/SimulatorMonitor.m
@@ -68,7 +68,7 @@
     if (self.failureCount) {
         self.exitStatus = BPExitStatusTestsFailed;
     } else {
-        self.exitStatus = BPExitStatusTestsAllPassed;
+        self.exitStatus = BPExitStatusAllTestsPassed;
     }
     [[BPStats sharedStats] endTimer:ALL_TESTS withResult:[BPExitStatusHelper stringFromExitStatus: self.exitStatus]];
     [BPUtils printInfo:INFO withString:@"All Tests Completed."];

--- a/bp/tests/BPUtilsTests.m
+++ b/bp/tests/BPUtilsTests.m
@@ -8,6 +8,7 @@
 //  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
 
 #import <XCTest/XCTest.h>
+#import "BPExitStatus.h"
 #import "BPUtils.h"
 #import "BPXCTestFile.h"
 #import "BPTestHelper.h"
@@ -108,6 +109,43 @@
         }
     }
     XCTAssert([testCasesWithParantheses count] == 0);
+}
+
+- (void) testExitStatus {
+    BPExitStatus exitCode;
+
+    exitCode = 0;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestsAllPassed"]);
+    exitCode = 1;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestsFailed"]);
+    exitCode = 2;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusSimulatorCreationFailed"]);
+    exitCode = 4;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusInstallAppFailed"]);
+    exitCode = 8;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusInterrupted"]);
+    exitCode = 16;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusSimulatorCrashed"]);
+    exitCode = 32;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusLaunchAppFailed"]);
+    exitCode = 64;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestTimeout"]);
+    exitCode = 128;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusAppCrashed"]);
+    exitCode = 256;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusSimulatorDeleted"]);
+    exitCode = 512;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusUninstallAppFailed"]);
+    exitCode = 1024;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusSimulatorReuseFailed"]);
+    exitCode = 3;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestsFailed BPExitStatusSimulatorCreationFailed"]);
+    exitCode = 192;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestTimeout BPExitStatusAppCrashed"]);
+    exitCode = 2048;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"UNKNOWN_BPEXITSTATUS - 2048"]);
+    exitCode = 2050;
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusSimulatorCreationFailed UNKNOWN_BPEXITSTATUS - 2048"]);
 }
 
 @end

--- a/bp/tests/BPUtilsTests.m
+++ b/bp/tests/BPUtilsTests.m
@@ -115,7 +115,7 @@
     BPExitStatus exitCode;
 
     exitCode = 0;
-    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestsAllPassed"]);
+    XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusAllTestsPassed"]);
     exitCode = 1;
     XCTAssert([[BPExitStatusHelper stringFromExitStatus: exitCode] isEqualToString:@"BPExitStatusTestsFailed"]);
     exitCode = 2;

--- a/bp/tests/BluepillTests.m
+++ b/bp/tests/BluepillTests.m
@@ -53,7 +53,6 @@
     self.config.videoPaths = @[[BPTestHelper sampleVideoPath]];
     self.config.testRunnerAppPath = nil;
     self.config.testing_CrashAppOnLaunch = NO;
-    self.config.testing_ExecutionPlan = @"";
     self.config.cloneSimulator = NO;
     [BPUtils quietMode:[BPUtils isBuildScript]];
     [BPUtils enableDebugOutput:NO];
@@ -214,7 +213,6 @@
     NSString *tempDir = NSTemporaryDirectory();
     NSError *error;
     NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppCrashingTestsSetTempDir", tempDir] withError:&error];
-    // NSLog(@"output directory is %@", outputDir);
     self.config.outputDirectory = outputDir;
     self.config.errorRetriesCount = @1;
     self.config.failureTolerance = @1;
@@ -302,8 +300,8 @@
 - (void)testReportWithAppHangingTestsShouldReturnFailure {
     self.config.stuckTimeout = @6;
     self.config.failureTolerance = @0;
-    self.config.errorRetriesCount = @4;
-    self.config.testing_ExecutionPlan = @"TIMEOUT";
+    self.config.errorRetriesCount = @3;
+    self.config.testing_ExecutionPlan = @"TIMEOUT TIMEOUT TIMEOUT TIMEOUT";
     NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     NSString *tempDir = NSTemporaryDirectory();
@@ -338,6 +336,110 @@
 
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssertTrue(exitCode == BPExitStatusAppCrashed);
+}
+
+/**
+ Execution plan: CRASH, TIMEOUT, PASS
+ */
+- (void)testReportFailureOnCrashTimeoutAndPass {
+    self.config.stuckTimeout = @6;
+    self.config.testing_ExecutionPlan = @"CRASH TIMEOUT PASS";
+    self.config.errorRetriesCount = @4;
+    self.config.onlyRetryFailed = TRUE;
+    NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppHangingTestsSetTempDir", tempDir] withError:&error];
+    NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusAppCrashed);
+}
+
+/**
+ Execution plan: FAIL, TIMEOUT, PASS
+ */
+- (void)testReportSuccessOnFailTimeoutAndPass {
+    self.config.stuckTimeout = @6;
+    self.config.failureTolerance = @1;
+    self.config.testing_ExecutionPlan = @"FAIL TIMEOUT PASS";
+    self.config.errorRetriesCount = @4;
+    self.config.onlyRetryFailed = TRUE;
+    NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppHangingTestsSetTempDir", tempDir] withError:&error];
+    NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusTestsAllPassed);
+}
+
+/**
+ Execution plan: FAIL, TIMEOUT, PASS
+ */
+- (void)testReportFailureOnFailTimeoutAndPass {
+    self.config.stuckTimeout = @6;
+    self.config.failureTolerance = @0;
+    self.config.testing_ExecutionPlan = @"FAIL TIMEOUT PASS";
+    self.config.errorRetriesCount = @4;
+    self.config.onlyRetryFailed = TRUE;
+    NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppHangingTestsSetTempDir", tempDir] withError:&error];
+    NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusTestsFailed);
+}
+
+/**
+ Execution plan: TIMEOUT, PASS
+ */
+- (void)testReportSuccessOnTimeoutAndPassOnRetry {
+    self.config.stuckTimeout = @6;
+    self.config.testing_ExecutionPlan = @"TIMEOUT PASS";
+    self.config.errorRetriesCount = @4;
+    self.config.onlyRetryFailed = NO;  // Not relevant
+    self.config.failureTolerance = @0;  // Not relevant
+    NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppHangingTestsSetTempDir", tempDir] withError:&error];
+    NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusTestsAllPassed);
+}
+
+/**
+ Execution plan: FAIL, PASS
+ */
+- (void)testReportSuccessOnTestFailedAndPassOnRetry {
+    self.config.stuckTimeout = @6;
+    self.config.failureTolerance = @1;
+    self.config.testing_ExecutionPlan = @"FAIL PASS";
+    self.config.errorRetriesCount = @4;
+    self.config.onlyRetryFailed = TRUE;
+    NSString *testBundlePath = [BPTestHelper sampleAppHangingTestsBundlePath];
+    self.config.testBundlePath = testBundlePath;
+    NSString *tempDir = NSTemporaryDirectory();
+    NSError *error;
+    NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppHangingTestsSetTempDir", tempDir] withError:&error];
+    NSLog(@"output directory is %@", outputDir);
+    self.config.outputDirectory = outputDir;
+
+    BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
+    XCTAssertTrue(exitCode == BPExitStatusTestsAllPassed);
 }
 
 - (void)testReportWithFailingTestsSetAndDiagnostics {

--- a/bp/tests/Resource Files/hanging_tests.xml
+++ b/bp/tests/Resource Files/hanging_tests.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="All tests" tests="1" failures="1" errors="0">
-    <testsuite tests="1" failures="1" errors="0" name="BPSampleAppHangingTests.xctest">
-        <testsuite tests="1" failures="1" errors="0" name="BPSampleAppHangingTests">
+<testsuites name="All tests" tests="2" failures="1" errors="0">
+    <testsuite tests="2" failures="1" errors="0" name="BPSampleAppHangingTests.xctest">
+        <testsuite tests="2" failures="1" errors="0" name="BPSampleAppHangingTests">
+            <testcase classname="BPSampleAppHangingTests" name="testASimpleTest"></testcase>
             <testcase classname="BPSampleAppHangingTests" name="testBasedOnExecutionPlan">
                 <failure type="Failure" message="Timed out waiting for the test to produce output. Test was aborted.">
                 </failure>

--- a/bp/tests/Resource Files/hanging_tests.xml
+++ b/bp/tests/Resource Files/hanging_tests.xml
@@ -2,7 +2,7 @@
 <testsuites name="All tests" tests="1" failures="1" errors="0">
     <testsuite tests="1" failures="1" errors="0" name="BPSampleAppHangingTests.xctest">
         <testsuite tests="1" failures="1" errors="0" name="BPSampleAppHangingTests">
-            <testcase classname="BPSampleAppHangingTests" name="testAppHanging">
+            <testcase classname="BPSampleAppHangingTests" name="testBasedOnExecutionPlan">
                 <failure type="Failure" message="Timed out waiting for the test to produce output. Test was aborted.">
                 </failure>
                 <system-out>


### PR DESCRIPTION
When a test times out, fails, crashes the app or successfully passes the bundle exits with an appropriate exit status. Often times, one or more tests in the bundle can exhibit one or more of these behaviors in one single execution of a test bundle.  However, the testing of this part of Bluepill's logic is limited right now partially because the combinations are exponential. Another reason is the lack of an easy-to-use mechanism to reproduce/mock different scenarios.

This PR is an attempt to add that ability along with a bunch of new tests and fix any bugs discovered.

With the new ability to test multiple cascading failure scenarios, a few more tests were added to uncover some known issues in exit status.

1. Bluepill tries to merge exit statuses with a `|` operator but since the exit status codes are not mergeable it is resulting in unexpected behavior. For example, if a bundle has `BPExitStatusTestsFailed` and `BPExitStatusTestTimeout`, then the final exit status is returned as `BPExitStatusAppCrashed` because `6 | 1 = 7`. 
**Fix:** Change the Exit Status codes to powers of 2 to make them mergeable.

2. The exit status codes are not always merged in the same way making it difficult and complicated to predict the behavior.
**Solution:** Simplified the Exit Status consolidation/aggregation logic. In case of failure, report all exit statuses that happened over multiple attempts.

3. The `hasRemainingTestsInContext()` is not capable of delivering the exact precise answer to the question... Are there more tests left to execute? partially because of a known issue (https://github.com/linkedin/bluepill/issues/352). So, depending on that is sometimes leading to an extra simulator attempt even after there are no tests left to execute.
**Fix:** Considering the return of `BPExitStatusTestsAllPassed` an indication from Simulator that "all tests there are to execute are done".  Another indication to end testing is when certain error occur and there are no more retries left.

\cc @ob @chenxiao0228