### PR TITLE
Support sidecar applications

### DIFF
--- a/bluepill/src/BPRunner.m
+++ b/bluepill/src/BPRunner.m
@@ -93,6 +93,7 @@ maxprocs(void)
     } else {
         cfg.environmentVariables = bundle.environmentVariables;
     }
+    cfg.dependencies = bundle.dependencies;
     if (self.config.cloneSimulator) {
         cfg.templateSimUDID = self.testHostSimTemplates[bundle.testHostPath];
     }

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -22,6 +22,7 @@
 @property (nonatomic, strong) NSString *testHost;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environment;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *arguments;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *> *dependencies;
 @property (nonatomic, strong) NSString *testBundlePath;
 @property (nonatomic, strong) NSString *testHostBundleIdentifier;
 @property (nonatomic, strong) NSString *uiTargetAppPath;
@@ -106,6 +107,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;
 @property (nonatomic, strong) NSDictionary<NSString *, BPTestPlan *> *tests;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *> *dependencies;
 
 // Media Assets
 @property (nonatomic, strong) NSArray<NSString *> *videoPaths; // The videos to be pushed into each simulator.

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -164,9 +164,6 @@ static NSUUID *sessionID;
     if (!self.testHost) {
         [errors addObject:@"testHost field is nil"];
     }
-    if (!self.dependencies) {
-        [errors addObject:@"dependencies field is nil"];
-    }
     if ([errors count] > 0) {
         BP_SET_ERROR(errPtr,
                      [NSString stringWithFormat:@"Invalid BPTestPlan object, %@.",

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -164,6 +164,9 @@ static NSUUID *sessionID;
     if (!self.testHost) {
         [errors addObject:@"testHost field is nil"];
     }
+    if (!self.dependencies) {
+        [errors addObject:@"dependencies field is nil"];
+    }
     if ([errors count] > 0) {
         BP_SET_ERROR(errPtr,
                      [NSString stringWithFormat:@"Invalid BPTestPlan object, %@.",
@@ -177,6 +180,7 @@ static NSUUID *sessionID;
     BPTestPlan *c = [[BPTestPlan alloc] init];
     c.arguments = [self.arguments copy];
     c.environment = [self.environment copy];
+    c.dependencies = [self.dependencies copy];
     c.testBundlePath = [self.testBundlePath copy];
     c.testHost = [self.testHost copy];
     return c;
@@ -332,6 +336,9 @@ static NSUUID *sessionID;
     if (self.environmentVariables) {
         [dict setValue:self.environmentVariables forKey:@"environmentVariables"];
     }
+    if (self.dependencies) {
+        [dict setValue:self.dependencies forKey:@"dependencies"];
+    }
     if ([NSJSONSerialization isValidJSONObject:dict]) {
         NSError *err;
         NSData *json = [NSJSONSerialization dataWithJSONObject:dict
@@ -377,6 +384,7 @@ static NSUUID *sessionID;
     newConfig.xcTestRunDict = self.xcTestRunDict;
     newConfig.commandLineArguments = self.commandLineArguments;
     newConfig.environmentVariables = self.environmentVariables;
+    newConfig.dependencies = self.dependencies;
     newConfig.tests = self.tests;
 
     return newConfig;
@@ -522,9 +530,10 @@ static NSUUID *sessionID;
         BP_SET_ERROR(errPtr, @"Number of simulators set to %lu but there cannot be fewer than one simulator.", self.numSims.integerValue);
         return NO;
     }
-    // Pull out two keys that are undocumented but needed for supporting xctest
+    // Pull out three keys that are undocumented but needed for supporting xctest
     self.commandLineArguments = [configDict objectForKey:@"commandLineArguments"];
     self.environmentVariables = [configDict objectForKey:@"environmentVariables"];
+    self.dependencies = [configDict objectForKey:@"dependencies"];
 
     return YES;
 }
@@ -555,6 +564,7 @@ static NSUUID *sessionID;
         plan.uiTargetAppPath = [planDictionary objectForKey:@"ui_target_app_path"];
         plan.environment = [planDictionary objectForKey:@"environment"];
         plan.arguments = [planDictionary objectForKey:@"arguments"];
+        plan.dependencies = [planDictionary objectForKey:@"dependencies"];
 
         if (![plan isValid:errPtr]) {
             BP_SET_ERROR(errPtr, @"Invalid BPTestPlan configuration: %@", plan);

--- a/bp/src/BPXCTestFile.h
+++ b/bp/src/BPXCTestFile.h
@@ -21,6 +21,7 @@
 @property (nonatomic, strong) NSString *UITargetAppPath;
 @property (nonatomic, strong) NSArray<NSString *> *skipTestIdentifiers;
 @property (nonatomic, strong) NSNumber *estimatedExecutionTime;
+@property (nonatomic, strong) NSDictionary <NSString *, NSString *> *dependencies;
 
 // All test classes in the test bundle
 @property (nonatomic, strong) NSArray *testClasses;

--- a/bp/src/BPXCTestFile.m
+++ b/bp/src/BPXCTestFile.m
@@ -11,6 +11,7 @@
 #import "BPConstants.h"
 #import "BPTestClass.h"
 #import "BPUtils.h"
+#import "SimulatorHelper.h"
 
 @implementation BPXCTestFile
 
@@ -162,6 +163,16 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
     if (skipTestIdentifiers) {
         xcTestFile.skipTestIdentifiers = [[NSArray alloc] initWithArray:skipTestIdentifiers];
     }
+    NSArray<NSString *> *dependencies = [dict objectForKey:@"DependentProductPaths"];
+    if (dependencies) {
+        NSMutableDictionary <NSString *, NSString *> *dependenciesWithBundleIDs = [NSMutableDictionary dictionary];
+        for (NSString *dependency in dependencies) {
+            NSString *expandedDependency = [dependency stringByReplacingOccurrencesOfString:TESTROOT withString:testRoot];
+            NSString *bundleID = [SimulatorHelper bundleIdForPath:expandedDependency];
+            dependenciesWithBundleIDs[bundleID] = expandedDependency;
+        }
+        xcTestFile.dependencies = dependenciesWithBundleIDs;
+    }
     return xcTestFile;
 }
 
@@ -176,6 +187,7 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
                                 withError:errPtr];
     xcTestFile.name = name;
     xcTestFile.environmentVariables = testPlan.environment;
+    xcTestFile.dependencies = testPlan.dependencies;
     
     NSMutableArray<NSString *> *args = [[NSMutableArray alloc] initWithCapacity:testPlan.arguments.count * 2];
     for (NSString *key in xcTestFile.commandLineArguments) {
@@ -231,6 +243,7 @@ NSString *objcNmCmdline = @"nm -U '%@' | grep ' t ' | cut -d' ' -f3,4 | cut -d'-
         copy.testClasses = self.testClasses;
         copy.commandLineArguments = self.commandLineArguments;
         copy.environmentVariables = self.environmentVariables;
+        copy.dependencies = self.dependencies;
         copy.testHostPath = self.testHostPath;
         copy.testHostBundleIdentifier = self.testHostBundleIdentifier;
         copy.testBundlePath= self.testBundlePath;

--- a/bp/src/SimulatorHelper.m
+++ b/bp/src/SimulatorHelper.m
@@ -106,7 +106,7 @@
     testHostPath = config.appBundlePath;
 
     NSString *bundleID = [self bundleIdForPath:config.appBundlePath];
-    xctConfig.testApplicationDependencies = @{bundleID: config.appBundlePath};
+    xctConfig.testApplicationDependencies = config.dependencies.count > 0 ? config.dependencies : @{bundleID: config.appBundlePath};
 
     if (config.testRunnerAppPath) {
         xctConfig.targetApplicationBundleID = bundleID;


### PR DESCRIPTION
This is a sibling diff to facebook/buck#2346. It allows Bluepill to ingest a list of dependencies from:
 - the `DependentProductPaths ` field in the `xctestrun` files, or 
 - the `dependencies` key in the test plan file.

At Dropbox, to test correct inter-op with third party applications, our UI tests have a secondary "sidecar" app. During the UI testing, they need to be built and installed together with the main app. The Xcode's default test runner is able to take care of this, as long as the the generated test configuration contains the `testApplicationDependencies`.

Tested this with our apps - the sidecar app installs correctly and tests pass! 🎉 