### PR TITLE
Only reference libXCTestBundleInject.dylib if it exists

### DIFF
--- a/bp/src/SimulatorHelper.m
+++ b/bp/src/SimulatorHelper.m
@@ -65,11 +65,16 @@
     NSString *hostAppExecPath = [SimulatorHelper executablePathforPath:config.appBundlePath];
     NSString *hostAppPath = [hostAppExecPath stringByDeletingLastPathComponent];
     NSString *testSimulatorFrameworkPath = [hostAppPath stringByDeletingLastPathComponent];
-    NSString *libXCTestBundleInject = [[hostAppPath stringByAppendingPathComponent:@"Frameworks"] stringByAppendingPathComponent:@"libXCTestBundleInject.dylib"];
+    NSString *libXCTestBundleInjectPath = [[hostAppPath stringByAppendingPathComponent:@"Frameworks"] stringByAppendingPathComponent:@"libXCTestBundleInject.dylib"];
+    NSString *libXCTestBundleInjectValue = libXCTestBundleInjectPath;
+    if (![NSFileManager.defaultManager fileExistsAtPath:libXCTestBundleInjectPath]) {
+        [BPUtils printInfo:DEBUGINFO withString:@"Not injecting libXCTestBundleInject dylib because it was not found in the app host bundle at path: %@", libXCTestBundleInjectValue];
+        libXCTestBundleInjectValue = @"";
+    }
     NSMutableDictionary<NSString *, NSString *> *environment = [@{
                                                                   @"DYLD_FALLBACK_FRAMEWORK_PATH" : [NSString stringWithFormat:@"%@/Library/Frameworks:%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath, config.xcodePath],
                                                                   @"DYLD_FALLBACK_LIBRARY_PATH" : [NSString stringWithFormat:@"%@/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib", config.xcodePath],
-                                                                  @"DYLD_INSERT_LIBRARIES" : libXCTestBundleInject,
+                                                                  @"DYLD_INSERT_LIBRARIES" : libXCTestBundleInjectValue,
                                                                   @"DYLD_LIBRARY_PATH" : [NSString stringWithFormat:@"%@/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks", config.xcodePath],
                                                                   @"DYLD_ROOT_PATH" : [NSString stringWithFormat:@"%@/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot", config.xcodePath],
                                                                   @"NSUnbufferedIO" : @"1",


### PR DESCRIPTION
App will crash if this dylib does not exist in the host app bundle. This dylib is not required for tests to run.