### PR TITLE
Update bazel build script and bazel rule

### DIFF
--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -122,7 +122,7 @@
     for (BPXMLReport *report in sortedReports) {
         [BPUtils printInfo:DEBUGINFO withString:@"MERGING REPORT: %@", [[report url] path]];
         @autoreleasepool {
-            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];   
+            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];
             if (err) {
                 [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
                 [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];

--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -122,7 +122,7 @@
     for (BPXMLReport *report in sortedReports) {
         [BPUtils printInfo:DEBUGINFO withString:@"MERGING REPORT: %@", [[report url] path]];
         @autoreleasepool {
-            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];
+            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:NSXMLDocumentTidyXML error:&err];            
             if (err) {
                 [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
                 [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];

--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -122,7 +122,7 @@
     for (BPXMLReport *report in sortedReports) {
         [BPUtils printInfo:DEBUGINFO withString:@"MERGING REPORT: %@", [[report url] path]];
         @autoreleasepool {
-            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:NSXMLDocumentTidyXML error:&err];            
+            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];            
             if (err) {
                 [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
                 [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];

--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -122,7 +122,7 @@
     for (BPXMLReport *report in sortedReports) {
         [BPUtils printInfo:DEBUGINFO withString:@"MERGING REPORT: %@", [[report url] path]];
         @autoreleasepool {
-            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];            
+            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];   
             if (err) {
                 [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
                 [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];

--- a/bptestrunner/bluepill_batch_test.bzl
+++ b/bptestrunner/bluepill_batch_test.bzl
@@ -50,16 +50,16 @@ def _bluepill_batch_test_impl(ctx):
     substitutions = {
         "test_bundle_paths": " ".join(test_bundle_paths),
         "test_host_paths": " ".join(test_host_paths),
-        "bp_test_plan": test_plan_file.basename,
+        "bp_test_plan": test_plan_file.short_path,
         "bp_path": ctx.executable._bp_exec.short_path,
         "bluepill_path": ctx.executable._bluepill_exec.short_path,
         "target_name": ctx.attr.name,
     }
     if ctx.attr.config_file:
-        runfiles += [ctx.file.config_file]
+        runfiles.append(ctx.file.config_file)
         substitutions["bp_config_file"] = ctx.file.config_file.path
     if ctx.attr.time_estimates:
-        runfiles += [ctx.file.time_estimates]
+        runfiles.append(ctx.file.time_estimates)
         substitutions["bp_test_time_estimates_json"] = ctx.file.time_estimates.path
     ctx.actions.expand_template(
         template = ctx.file._test_runner_template,
@@ -134,12 +134,10 @@ as possible between simulators.
     },
     doc = """
 Test rule to aggregate a list of test rules and pass them for bluepill for execution
-
 Outputs:
 Runfiles:
 files: The files needed during runtime for the test to be performed. It contains the
 test plan json file, bluepill config file if specified, xctest bundles, test hosts.
-
 This rule WILL disregard the bluepill output folder configuration if it's set in the
 config json file. Instead it will copy all the outputs to ./bazel-testlogs/$TARGET_NAME/test.outputs/
 """,

--- a/bptestrunner/bluepill_batch_test_runner.template.sh
+++ b/bptestrunner/bluepill_batch_test_runner.template.sh
@@ -60,19 +60,22 @@ if [ -f "$BP_TEST_ESTIMATE_JSON" ]; then
     TIME_ESTIMATE_ARG="--test-time-estimates-json $(basename "$BP_TEST_ESTIMATE_JSON")"
 fi
 
-#  Copy bluepill, bp executable and the rule generated test plan file to working folder
+# Copy rule-generated test plan file to working folder
 cp "$BP_TEST_PLAN" $BP_WORKING_FOLDER
+BP_TEST_PLAN_ARG="$(basename "$BP_TEST_PLAN")"
+
+# Copy bluepill and bp executables to working folder
 cp "$BP_PATH" $BP_WORKING_FOLDER
 cp "$BLUEPILL_PATH" $BP_WORKING_FOLDER
 
 # Run bluepill
 # NOTE: we override output folder here and disregard the one in the config file.
 # So we know where to grab the output files for the next step.
-echo "Running ./bluepill --test-plan-path "${BP_TEST_PLAN}" -o "outputs" ${CONFIG_ARG} ${TIME_ESTIMATE_ARG}"
+echo "Running ./bluepill --test-plan-path "${BP_TEST_PLAN_ARG}" -o "outputs" ${CONFIG_ARG} ${TIME_ESTIMATE_ARG}"
 
 cd $BP_WORKING_FOLDER
 RC=0
-(./bluepill --test-plan-path "${BP_TEST_PLAN}" -o "outputs" ${CONFIG_ARG} ${TIME_ESTIMATE_ARG}) || RC=$?
+(./bluepill --test-plan-path "${BP_TEST_PLAN_ARG}" -o "outputs" ${CONFIG_ARG} ${TIME_ESTIMATE_ARG}) || RC=$?
 # Move Bluepill output to bazel-testlogs
 ditto "outputs" "$TEST_UNDECLARED_OUTPUTS_DIR"
 rm -rf "outputs"


### PR DESCRIPTION
Change `test_plan_file.basename` to `test_plan_file.short_path`, then modify the runner script template to pass only the basename to the bluepill executable, similar to what is done with BP_CONFIG_FILE here: https://github.com/linkedin/bluepill/blob/master/bptestrunner/bluepill_batch_test_runner.template.sh#L53