### PR TITLE
Add NSXMLDocumentTidyXML as option to NSXMLDocument

### DIFF
--- a/bluepill/src/BPReportCollector.m
+++ b/bluepill/src/BPReportCollector.m
@@ -122,7 +122,7 @@
     for (BPXMLReport *report in sortedReports) {
         [BPUtils printInfo:DEBUGINFO withString:@"MERGING REPORT: %@", [[report url] path]];
         @autoreleasepool {
-            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:0 error:&err];
+            NSXMLDocument *xmlDoc = [[NSXMLDocument alloc] initWithContentsOfURL:[report url] options:NSXMLDocumentTidyXML error:&err];
             if (err) {
                 [BPUtils printInfo:ERROR withString:@"Failed to parse '%@': %@", [[report url] path], [err localizedDescription]];
                 [BPUtils printInfo:ERROR withString:@"SOME TESTS MIGHT BE MISSING"];


### PR DESCRIPTION
We noticed that when we run our XCUITests with bluepill, we need to pass in `NSXMLDocumentTidyXML` as an option when generating the XML results, since Apple's XCUITest output includes some illegal characters, such as "_&quot;_"; below:

    t =    47.17s Find: Elements matching predicate &#x27;&quot;create_channel_privacy_switch&quot; IN identifiers&#x27;

Apple's XCUITest framework prints these characters, and as far as I know, there isn't a way to control the verbosity level of XCUITest output logs. 

Per Apple's documentation here: 
https://developer.apple.com/documentation/foundation/nsxmldocument/1413086-initwithdata

"If you specify NSXMLDocumentTidyXML as one of the options, NSXMLDocument performs several clean-up operations on the document XML (such as removing leading tabs). It does respect the xml:space="preserve" attribute when it attempts to tidy the XML."