### PR TITLE
Replaced BP_MASTER and BP_SLAVE with inclusive terminology

### DIFF
--- a/bluepill/src/main.m
+++ b/bluepill/src/main.m
@@ -66,7 +66,7 @@ int main(int argc, char * argv[]) {
         [BPStats sharedStats];
 
         [[BPStats sharedStats] startTimer:@"Bluepill Initializing"];
-        BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_MASTER];
+        BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BLUEPILL_BINARY];
         struct option *lopts = [config getLongOptions];
         char *sopts = [config getShortOptions];
         if (argv[1] && (!strcmp(argv[1], "version") || (!strcmp(argv[1], "--version")))) {

--- a/bluepill/tests/BPCLITests.m
+++ b/bluepill/tests/BPCLITests.m
@@ -31,7 +31,7 @@
 
 - (void)testAdditionalTestBundles {
     NSError *err;
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     config.appBundlePath = [BPTestHelper sampleAppPath];
     [config saveOpt:[NSNumber numberWithInt:'a'] withArg:[BPTestHelper sampleAppPath]];
     [config saveOpt:[NSNumber numberWithInt:'t'] withArg:[BPTestHelper sampleAppBalancingTestsBundlePath]];
@@ -46,7 +46,7 @@
 
 - (void)testXcodePathIsWrong {
     NSError *err;
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_MASTER];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BLUEPILL_BINARY];
     [config saveOpt:[NSNumber numberWithInt:'a'] withArg:[BPTestHelper sampleAppPath]];
     [config saveOpt:[NSNumber numberWithInt:'X'] withArg:@"/this/is/an/invalid/path"];
     

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -24,7 +24,7 @@
 - (BPConfiguration *)generateConfigWithVideoDir:(NSString *)videoDir {
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_MASTER];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BLUEPILL_BINARY];
     config.testBundlePath = testBundlePath;
     config.appBundlePath = hostApplicationPath;
     config.stuckTimeout = @80;

--- a/bluepill/tests/BPPackerTests.m
+++ b/bluepill/tests/BPPackerTests.m
@@ -28,7 +28,7 @@
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
     self.config = [BPConfiguration new];
-    self.config.program = BP_MASTER;
+    self.config.program = BLUEPILL_BINARY;
     self.config.testBundlePath = testBundlePath;
     self.config.appBundlePath = hostApplicationPath;
     self.config.stuckTimeout = @30;

--- a/bluepill/tests/BPRunnerTests.m
+++ b/bluepill/tests/BPRunnerTests.m
@@ -29,7 +29,7 @@
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
     self.config = [BPConfiguration new];
-    self.config.program = BP_MASTER;
+    self.config.program = BLUEPILL_BINARY;
     self.config.testBundlePath = testBundlePath;
     self.config.appBundlePath = hostApplicationPath;
     self.config.stuckTimeout = @30;

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -43,8 +43,8 @@
 @interface BPConfiguration : NSObject <NSCopying>
 
 typedef NS_ENUM(NSInteger, BPProgram) {
-    BP_MASTER = 1,
-    BP_SLAVE = 2,
+    BLUEPILL_BINARY = 1,
+    BP_BINARY = 2,
 };
 
 /*
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic) BOOL quiet;
 @property (nonatomic, strong) NSString *deleteSimUDID;
 @property (nonatomic) BOOL keepSimulator;
-@property (nonatomic) BPProgram program; // one of BP_MASTER or BP_SLAVE
+@property (nonatomic) BPProgram program; // one of BLUEPILL_BINARY or BP_BINARY
 @property (nonatomic) BOOL verboseLogging;
 @property (nonatomic, strong) NSNumber *maxCreateTries;
 @property (nonatomic, strong) NSNumber *maxInstallTries;

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -31,7 +31,7 @@ typedef NS_OPTIONS(NSUInteger, BPOptionType) {
 struct BPOptions {
     int          val;          // short option (e.g. -f)
     const char   *name;        // long name of the option (e.g. --foobar)
-    int          program;      // BP_MASTER, BP_SLAVE, or both (BP_MASTER | BP_SLAVE)
+    int          program;      // BLUEPILL_BINARY, BP_BINARY, or both (BLUEPILL_BINARY | BP_BINARY)
     BOOL         required;     // Whether the option is required or optional
     BOOL         seen;         // Whether we've seen the option in processing.
     int          has_arg;      // One of: no_argument, required_argument, optional_argument
@@ -42,111 +42,111 @@ struct BPOptions {
 } BPOptions[] = {
 
     // Required argument
-    {'a', "app", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "appBundlePath",
+    {'a', "app", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "appBundlePath",
         "The path to the host application to execute (your .app)"},
-    {'t', "test-bundle-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
+    {'t', "test-bundle-path", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testBundlePath",
         "The test bundle to run tests."},
 
     // Required arguments for ui testing
-    {'u', "runner-app-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testRunnerAppPath",
+    {'u', "runner-app-path", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testRunnerAppPath",
         "The test runner for UI tests."},
 
     // Optional argument
-    {'d', "device", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_DEVICE_TYPE, BP_VALUE, "deviceType",
+    {'d', "device", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, BP_DEFAULT_DEVICE_TYPE, BP_VALUE, "deviceType",
         "On which device to run the app."},
-    {'U', "templateSimUDID", BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "templateSimUDID",
+    {'U', "templateSimUDID", BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE, "templateSimUDID",
         "BP master use this flag to tell BP worker which template simulator to use"},
-    {'c', "config", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "configFile",
+    {'c', "config", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE, "configFile",
         "Read options from the specified configuration file instead of the command line"},
-    {'C', "repeat-count", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "1", BP_VALUE | BP_INTEGER, "repeatTestsCount",
+    {'C', "repeat-count", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "1", BP_VALUE | BP_INTEGER, "repeatTestsCount",
         "Number of times we'll run the entire test suite (used for stability testing)."},
-    {'N', "no-split", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "noSplit",
+    {'N', "no-split", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST, "noSplit",
         "A list of NO split test bundles"},
-    {'P', "print-config", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "stdout", BP_VALUE, "configOutputFile",
+    {'P', "print-config", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "stdout", BP_VALUE, "configOutputFile",
         "Print a configuration file suitable for passing back using the `-c` option."},
-    {'R', "error-retries", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "4", BP_VALUE | BP_INTEGER, "errorRetriesCount",
+    {'R', "error-retries", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "4", BP_VALUE | BP_INTEGER, "errorRetriesCount",
         "Number of times we'll recover from crashes to continue running the current test suite."},
-    {'S', "stuck-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "stuckTimeout",
+    {'S', "stuck-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "stuckTimeout",
         "Timeout in seconds for a test that seems stuck (no output)."},
-    {'T', "test-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "testCaseTimeout",
+    {'T', "test-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "testCaseTimeout",
         "Timeout in seconds for a test that is producing output."},
-    {'f', "failure-tolerance", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "0", BP_VALUE | BP_INTEGER, "failureTolerance",
+    {'f', "failure-tolerance", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "0", BP_VALUE | BP_INTEGER, "failureTolerance",
         "The number of retries on any failures (app crash/test failure)."},
-    {'i', "include", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToRun",
+    {'i', "include", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST, "testCasesToRun",
         "Include a testcase in the set of tests to run (unless specified in `exclude`)."},
-    {'n', "num-sims", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "4", BP_VALUE | BP_INTEGER, "numSims",
+    {'n', "num-sims", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "4", BP_VALUE | BP_INTEGER, "numSims",
         "Number of simulators to run in parallel. (bluepill only)"},
-    {'o', "output-dir", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "outputDirectory",
+    {'o', "output-dir", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "outputDirectory",
         "Directory where to put output log files (bluepill only)."},
-    {'j', "test-time-estimates-json", BP_MASTER, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testTimeEstimatesJsonFile",
+    {'j', "test-time-estimates-json", BLUEPILL_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testTimeEstimatesJsonFile",
         "Path of the input file with test execution time estimates."},
-    {'r', "runtime", BP_MASTER | BP_SLAVE, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
+    {'r', "runtime", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, BP_DEFAULT_RUNTIME, BP_VALUE, "runtime",
         "What runtime to use."},
-    {'x', "exclude", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
+    {'x', "exclude", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST, "testCasesToSkip",
         "Exclude a testcase in the set of tests to run (takes priority over `include`)."},
-    {'X', "xcode-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "xcodePath",
+    {'X', "xcode-path", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "xcodePath",
         "Path to xcode."},
-    {'D', "delete-simulator", BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE, "deleteSimUDID",
+    {'D', "delete-simulator", BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE, "deleteSimUDID",
         "The device UUID of simulator to delete. Using this option enables a DELETE-ONLY-MODE. (BP INTERNAL USE ONLY). "},
-    {'V', "video-paths", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "videoPaths",
+    {'V', "video-paths", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "videoPaths",
         "Paths to the videos to be uploaded."},
-    {'I', "image-paths", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "imagePaths",
+    {'I', "image-paths", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "imagePaths",
         "Paths to the images to be uploaded."},
 
     // options with no argument
-    {'L', "clone-simulator", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "cloneSimulator",
+    {'L', "clone-simulator", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "cloneSimulator",
         "Run test with clone-simulator"},
-    {'H', "headless", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "headlessMode",
+    {'H', "headless", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "headlessMode",
         "Run in headless mode (no GUI)."},
-    {'h', "help", BP_MASTER | BP_SLAVE, NO, NO, no_argument, NULL, BP_VALUE, NULL,
+    {'h', "help", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, NULL, BP_VALUE, NULL,
         "This help."},
-    {'q', "quiet", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "quiet",
+    {'q', "quiet", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "quiet",
         "Turn off all output except fatal errors."},
-    {'F', "only-retry-failed", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "onlyRetryFailed",
+    {'F', "only-retry-failed", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "onlyRetryFailed",
         "Only retry failed tests instead of all. Also retry test that timed-out/crashed."},
-    {'l', "list-tests", BP_MASTER, NO, NO, no_argument, NULL, BP_VALUE | BP_BOOL, "listTestsOnly",
+    {'l', "list-tests", BLUEPILL_BINARY, NO, NO, no_argument, NULL, BP_VALUE | BP_BOOL, "listTestsOnly",
         "Only list tests and exit without executing tests."},
-    {'v', "verbose", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "verboseLogging",
+    {'v', "verbose", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "verboseLogging",
         "Enable verbose logging"},
-    {'k', "keep-individual-test-reports", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepIndividualTestReports",
+    {'k', "keep-individual-test-reports", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepIndividualTestReports",
         "Keep individual test reports, in addition to the aggregated final report"},
 
     // options without short-options
-    {349, "additional-unit-xctests", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "additionalUnitTestBundles",
+    {349, "additional-unit-xctests", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "additionalUnitTestBundles",
         "Additional XCTest bundles to test."},
-    {350, "additional-ui-xctests", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "additionalUITestBundles",
+    {350, "additional-ui-xctests", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_LIST | BP_PATH, "additionalUITestBundles",
         "Additional XCUITest bundles to test."},
-    {352, "keep-simulator", BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepSimulator",
+    {352, "keep-simulator", BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepSimulator",
         "Don't delete the simulator device after one test bundle finish. (BP INTERNAL USE ONLY). "},
-    {353, "max-sim-create-attempts", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxCreateTries",
+    {353, "max-sim-create-attempts", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxCreateTries",
         "The maximum number of times to attempt to create a simulator before failing a test attempt"},
-    {354, "max-sim-install-attempts", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxInstallTries",
+    {354, "max-sim-install-attempts", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "2", BP_VALUE | BP_INTEGER, "maxInstallTries",
         "The maximum number of times to attempt to install the test app into a simulator before failing a test attempt"},
-    {356, "create-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "createTimeout",
+    {356, "create-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "createTimeout",
         "The maximum amount of time, in seconds, to wait before giving up on simulator creation"},
-    {357, "launch-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "launchTimeout",
+    {357, "launch-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "launchTimeout",
         "The maximum amount of time, in seconds, to wait before giving up on application launch in the simulator"},
-    {358, "delete-timeout", BP_MASTER | BP_SLAVE, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "deleteTimeout",
+    {358, "delete-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "300", BP_VALUE | BP_INTEGER, "deleteTimeout",
         "The maximum amount of time, in seconds, to wait before giving up on simulator deletion"},
 
     // New options
-    {359, "xctestrun-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "xcTestRunPath",
+    {359, "xctestrun-path", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "xcTestRunPath",
         "The .xctestrun file with test information."},
-    {360, "diagnostics", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "saveDiagnosticsOnError",
+    {360, "diagnostics", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "saveDiagnosticsOnError",
         "Save Simulator diagnostics and useful debugging information in the output directory. If no output directory it doesn't do anything."},
-    {361, "screenshots-directory", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "screenshotsDirectory",
+    {361, "screenshots-directory", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "screenshotsDirectory",
         "Directory where simulator screenshots for failed ui tests will be stored"},
-    {362, "simulator-preferences-file", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "simulatorPreferencesFile",
+    {362, "simulator-preferences-file", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "simulatorPreferencesFile",
         "A .GlobalPreferences.plist simulator preferences file to be copied to any newly created simulators before booting"},
-    {363, "script-file", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "scriptFilePath",
+    {363, "script-file", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "scriptFilePath",
         "A script that will be called after the simulator is booted, but before tests are run. Can be used to do any setup (e.g. installing certs). The environment will contain $BP_DEVICE_ID with the ID of the simulator and $BP_DEVICE_PATH with its full path. Exit with zero for success and non-zero for failure."},
-    {364, "test-plan-path", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testPlanPath",
+    {364, "test-plan-path", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "testPlanPath",
         "The path of a json file which describes the test plan. It is equivalent to the .xctestrun file generated by Xcode, but it can be generated by a different build system, e.g. Bazel"},
-    {365, "unsafe-skip-xcode-version-check", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "unsafeSkipXcodeVersionCheck",
+    {365, "unsafe-skip-xcode-version-check", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL , "unsafeSkipXcodeVersionCheck",
         "Skip Xcode version check if using an Xcode version that is not officially supported the Bluepill version being used. Not safe/recommended and has a limited support."},
-    {366, "retry-app-crash-tests", BP_MASTER | BP_SLAVE, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "retryAppCrashTests",
+    {366, "retry-app-crash-tests", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "retryAppCrashTests",
         "Retry the tests after an app crash and if it passes on retry, consider them non-fatal."},
-    {367, "videos-directory", BP_MASTER | BP_SLAVE, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "videosDirectory",
+    {367, "videos-directory", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, NULL, BP_VALUE | BP_PATH, "videosDirectory",
         "Directory where videos of test runs will be saved. If not provided, videos are not recorded."},
     {0, 0, 0, 0, 0, 0, 0}
 };
@@ -200,7 +200,7 @@ static NSUUID *sessionID;
 
 - (instancetype)initWithConfigFile:(NSString *)file forProgram:(BPProgram)program withError:(NSError **)errPtr {
     self = [super init];
-    if (program != BP_MASTER && program != BP_SLAVE) return nil;
+    if (program != BLUEPILL_BINARY && program != BP_BINARY) return nil;
     self.program = program;
     self.bpCmdLineArgs = [[NSMutableArray alloc] init];
     // set factory defaults
@@ -618,7 +618,7 @@ static NSUUID *sessionID;
     if (!(self.appBundlePath) && !(self.xcTestRunPath) && !(self.testPlanPath) && !(self.deleteSimUDID)) {
         [errors addObject:@"Missing required option: -a/--app OR --xctestrun-path OR --test-plan-path"];
     }
-    if ((self.program & BP_SLAVE) && !(self.testBundlePath) && !(self.testPlanPath) && !(self.deleteSimUDID)) {
+    if ((self.program & BP_BINARY) && !(self.testBundlePath) && !(self.testPlanPath) && !(self.deleteSimUDID)) {
         [errors addObject:@"Missing required option: -t/--test-bundle-path OR --xctestrun-path"];
     }
     if (errors.count > 0) {

--- a/bp/src/main.m
+++ b/bp/src/main.m
@@ -31,7 +31,7 @@ int main(int argc, char * argv[]) {
             exit(0);
         }
 
-        BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+        BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
 
         
         struct option *lopts = [config getLongOptions];

--- a/bp/tests/BPCLITests.m
+++ b/bp/tests/BPCLITests.m
@@ -31,7 +31,7 @@
 }
 
 - (void)testListArguments {
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     [config saveOpt:[NSNumber numberWithInt:'a'] withArg:[BPTestHelper sampleAppPath]];
     [config saveOpt:[NSNumber numberWithInt:'t'] withArg:[BPTestHelper sampleAppBalancingTestsBundlePath]];
     [config saveOpt:[NSNumber numberWithInt:'R'] withArg:@"2"];
@@ -74,7 +74,7 @@
     }
     NSError *error;
     BPConfiguration *config = [[BPConfiguration alloc] initWithConfigFile:tmpConfig
-                                                               forProgram:BP_SLAVE
+                                                               forProgram:BP_BINARY
                                                                 withError:&error];
     XCTAssert(config != nil);
     NSString *relpath = [[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:@"rel/path"];
@@ -107,10 +107,10 @@
     // First just try passing a file that doesn't exist
     BPConfiguration *config;
     
-    config = [[BPConfiguration alloc] initWithConfigFile:@"/tmp/this_file_should_not_exist" forProgram:BP_SLAVE withError:&err];
+    config = [[BPConfiguration alloc] initWithConfigFile:@"/tmp/this_file_should_not_exist" forProgram:BP_BINARY withError:&err];
     XCTAssert(config == nil);
     XCTAssert([[err localizedDescription] isEqualToString:@"The file “this_file_should_not_exist” couldn’t be opened because there is no such file."]);
-    config = [[BPConfiguration alloc] initWithConfigFile:tmpConfig forProgram:BP_SLAVE withError:&err];
+    config = [[BPConfiguration alloc] initWithConfigFile:tmpConfig forProgram:BP_BINARY withError:&err];
     XCTAssert(config == nil);
 //    NSLog(@"%@", err);
     XCTAssert([[err localizedDescription] isEqualToString:@"Expected type NSArray for key 'no-split', got __NSCFNumber. Parsing failed."]);

--- a/bp/tests/BPConfigurationTests.m
+++ b/bp/tests/BPConfigurationTests.m
@@ -42,7 +42,7 @@
 }
 
 - (void)testConfigFileLoading {
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     NSError *error;
     NSString *resourcePath = [BPTestHelper resourceFolderPath];
     NSString *configFile = [resourcePath stringByAppendingPathComponent:@"testConfig.json"];
@@ -66,7 +66,7 @@
 }
 
 - (void)testConfigFileWithRelativePathLoading {
-    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    BPConfiguration *config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     NSError *error;
     NSString *resourcePath = [BPTestHelper resourceFolderPath];
     NSString *configFile = [resourcePath stringByAppendingPathComponent:@"testConfigRelativePath.json"];

--- a/bp/tests/BPIntTestCase.m
+++ b/bp/tests/BPIntTestCase.m
@@ -23,7 +23,7 @@
     self.continueAfterFailure = NO;
     NSString *hostApplicationPath = [BPTestHelper sampleAppPath];
     NSString *testBundlePath = [BPTestHelper sampleAppNegativeTestsBundlePath];
-    self.config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    self.config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     self.config.testBundlePath = testBundlePath;
     self.config.appBundlePath = hostApplicationPath;
     self.config.stuckTimeout = @40;

--- a/bp/tests/BPTreeParserTests.m
+++ b/bp/tests/BPTreeParserTests.m
@@ -32,7 +32,7 @@
     [BPTreeAssembler.sharedInstance reset];
     [BPUtils quietMode:[BPUtils isBuildScript]];
     [BPUtils enableDebugOutput:![BPUtils isBuildScript]];
-    self.config = [[BPConfiguration alloc] initWithProgram:BP_SLAVE];
+    self.config = [[BPConfiguration alloc] initWithProgram:BP_BINARY];
     self.config.testing_NoAppWillRun = YES;
 }
 

--- a/bp/tests/BPUtilsTests.m
+++ b/bp/tests/BPUtilsTests.m
@@ -33,7 +33,7 @@
                                                        withError:nil];
     
     self.config = [BPConfiguration new];
-    self.config.program = BP_MASTER;
+    self.config.program = BLUEPILL_BINARY;
 }
 
 - (void)tearDown {


### PR DESCRIPTION
`BP_MASTER` -> `BLUEPILL_BINARY`
`BP_SLAVE` -> `BP_BINARY`

Build Succeeds locally:
```
RegisterExecutionPolicyException /Users/smuthu/Sandbox/bluepill/build/Build/Products/Release/bluepill (in target 'bluepill' from project 'bluepill')
    cd /Users/smuthu/Sandbox/bluepill/bluepill
    builtin-RegisterExecutionPolicyException /Users/smuthu/Sandbox/bluepill/build/Build/Products/Release/bluepill

** BUILD SUCCEEDED **

Release in build/Bluepill-v5.6.0-2-gabe80d2.zip
precmd: command not found: vcs_info 
```

However there are test failures (although they mirror the failures in master):
```
Failing tests:
        bp-tests:
                -[BPUtilsTests testNormalizingConfigurationDoesntExcludeTestSuiteWithSimilarPrefix]
                -[BPUtilsTests testNormalizingConfigurationOnlyIncludesTestsInIncludedTestSuite]
                -[BluepillTests testAppThatCrashesOnLaunch]
                -[BluepillTests testAppThatHangsOnLaunch]
                -[BluepillTests testCopySimulatorPreferencesFile]
                -[BluepillTests testDeleteSimulatorNotExistWithRetry]
                -[BluepillTests testDeleteSimulatorOnly]
                -[BluepillTests testKeepSimulatorWithAppCrashingTestsSet]
                -[BluepillTests testKeepSimulatorWithAppHangingTestsSet]
                -[BluepillTests testNoRetryOnCrash]
                -[BluepillTests testRecoverSimulatorOnCrash]
                -[BluepillTests testRetryOnlyFailures]
                -[BluepillTests testRunningAndIgnoringCertainTestCases]
                -[BluepillTests testRunningOnlyCertainTestcases]
                -[BluepillTests testRunScript]
                -[BluepillTests testRunUITest]
                -[BluepillTests testRunWithFailingTestsSet]
                -[BluepillTests testRunWithPassingTestsSet]
                -[BluepillTests testThatScreenshotAreNotTakenWithFailingTestsSetWithoutConfigOption]
```