### PR TITLE
Add BP index to fix trace-profile issue when BPs are reused

### DIFF
--- a/bluepill/src/BPRunner.h
+++ b/bluepill/src/BPRunner.h
@@ -31,12 +31,14 @@
  * @discussion Create a new Simulator wrapped in a `bp` process. It will run the specified bundle and execute the block once it finishes.
  * @param bundle The test bundle to execute.
  * @param number The simulator number (will be printed in logs).
+ * @param index The simulator index that keeps same when the simulator is reused.
  * @param block A completion block to execute when the NSTask has finished.
  * @return An NSTask ready to be executed via [task launch] or nil in failure.
  *
  */
 - (NSTask *)newTaskWithBundle:(BPXCTestFile *)bundle
                     andNumber:(NSUInteger)number
+                     andIndex:(NSUInteger)index
                     andDevice:(NSString *)deviceID
            andCompletionBlock:(void (^)(NSTask * ))block;
 

--- a/bp/src/BPStats.m
+++ b/bp/src/BPStats.m
@@ -184,10 +184,11 @@
 
 - (void)generateFullReportWithWriter:(BPWriter *)writer exitCode:(int)exitCode {
     unsigned long bundleID = [self bundleID];
+    unsigned long bpNum = [self bpNum];
     // Metadata
     NSString *threadName = @"Bluepill";
     if (bundleID > 0) {
-        threadName = [NSString stringWithFormat:@"BP-%lu", bundleID];
+        threadName = [NSString stringWithFormat:@"BP #%lu", bundleID];
     }
     [writer writeLine:[NSString stringWithFormat:@"{\"name\": \"thread_name\", \"ph\": \"M\", \"pid\": 1, \"tid\": %lu, \"args\": {\"name\": \"%@\"}},",
                        bundleID,
@@ -199,7 +200,11 @@
                        bundleID
                        ]];
 
-    NSString *name = [NSString stringWithFormat:@"%s (%d)", (bundleID > 0) ? "bp" : "bluepill", getpid()];
+    NSString *bundleName = @"Bluepill";
+    if (bpNum > 0) {
+        bundleName = [NSString stringWithFormat:@"BP-%lu", bpNum];
+    }
+    NSString *name = [NSString stringWithFormat:@"%@ (%d)", bundleName, getpid()];
     [writer writeLine:[NSString stringWithFormat:@"%@,",
                        [self completeEvent:name
                                        cat:@"process"
@@ -231,12 +236,21 @@
 #pragma mark Trace Event Formatting
 
 -(unsigned long)bundleID {
-    char *s = getenv("_BP_NUM");
+    char *s = getenv("_BP_INDEX");
     if (!s) {
         s = "0";
     }
     unsigned long bundleID = strtoul(s, 0, 10);
     return bundleID;
+}
+
+-(unsigned long)bpNum {
+    char *s = getenv("_BP_NUM");
+    if (!s) {
+        s = "0";
+    }
+    unsigned long bpNum = strtoul(s, 0, 10);
+    return bpNum;
 }
 
 - (NSString *)resultToCname:(NSString *)result {


### PR DESCRIPTION
**Issue:**
When a BP is reused, the id increases by 1 automatically, like BP-1 & BP-5. In the trace-profile, the stats will be listed in 2 separated lines, which is not friendly to check.

**Logic Changes:**
Added a parameter "_BP_INDEX" for bps, which would be 1 ~ SIMS_NUM, and keeps the same when a BP is reused.

**Trace-profile Changes:**
1. Reused BPs are listed in the same line.
2. Thread-name: "BP-[ID]" -> "BP #[INDEX]"
3. Event-name: "bp ([PROCESS_ID])" -> "BP-[ID] ([PROCESS_ID])"