### PR TITLE
Introduce BPSwimlane holding LaneID that keeps the same when reused.

### DIFF
--- a/bluepill/bluepill.xcodeproj/project.pbxproj
+++ b/bluepill/bluepill.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0173520F23679E0A008BFA4E /* BPHTMLReportWriteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0173520E23679E0A008BFA4E /* BPHTMLReportWriteTests.m */; };
 		0173521323679E87008BFA4E /* TEST-FinalReport.xml in Resources */ = {isa = PBXBuildFile; fileRef = 0173521223679E87008BFA4E /* TEST-FinalReport.xml */; };
 		56B74BCA1E4C0A15004E6624 /* BPIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 56B74BC91E4C0A15004E6624 /* BPIntegrationTests.m */; };
+		8A3B01062637140D00211DAB /* BPSwimlane.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAAC242604EF420084FB85 /* BPSwimlane.m */; };
+		8AEAAC252604EF420084FB85 /* BPSwimlane.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEAAC242604EF420084FB85 /* BPSwimlane.m */; };
 		B3109F792151F72F00B9309C /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3380AEE2150BD8700752E1B /* CoreSimulator.framework */; };
 		BA1809E91DBA8FC300D7D130 /* BPRunnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA1809E81DBA8FC300D7D130 /* BPRunnerTests.m */; };
 		BA1809EB1DBA910400D7D130 /* BPAppTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA1809EA1DBA910400D7D130 /* BPAppTests.m */; };
@@ -55,6 +57,8 @@
 		0173520E23679E0A008BFA4E /* BPHTMLReportWriteTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPHTMLReportWriteTests.m; sourceTree = "<group>"; };
 		0173521223679E87008BFA4E /* TEST-FinalReport.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "TEST-FinalReport.xml"; sourceTree = "<group>"; };
 		56B74BC91E4C0A15004E6624 /* BPIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPIntegrationTests.m; sourceTree = "<group>"; };
+		8AEAAC232604EF420084FB85 /* BPSwimlane.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPSwimlane.h; sourceTree = "<group>"; };
+		8AEAAC242604EF420084FB85 /* BPSwimlane.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPSwimlane.m; sourceTree = "<group>"; };
 		B3380AEE2150BD8700752E1B /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = ../../../../../../../Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<group>"; };
 		BA1809E01DBA8FB100D7D130 /* bluepill-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "bluepill-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA1809E41DBA8FB100D7D130 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -213,6 +217,8 @@
 				0173520D2366186A008BFA4E /* BPTestReportHTML.h */,
 				C41C41F71DB14B5F001F32A2 /* BPRunner.h */,
 				C41C41F81DB14B5F001F32A2 /* BPRunner.m */,
+				8AEAAC232604EF420084FB85 /* BPSwimlane.h */,
+				8AEAAC242604EF420084FB85 /* BPSwimlane.m */,
 				BAEF4B371DAC539400E68294 /* main.m */,
 			);
 			path = src;
@@ -351,6 +357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A3B01062637140D00211DAB /* BPSwimlane.m in Sources */,
 				BA1809E91DBA8FC300D7D130 /* BPRunnerTests.m in Sources */,
 				BA1809FB1DBA949600D7D130 /* BPPacker.m in Sources */,
 				BA1809EB1DBA910400D7D130 /* BPAppTests.m in Sources */,
@@ -376,6 +383,7 @@
 				0173520C2366110D008BFA4E /* BPHTMLReportWriter.m in Sources */,
 				BAD8484A1DBC6A83007034CF /* BPReportCollector.m in Sources */,
 				C41C41F31DB04032001F32A2 /* BPApp.m in Sources */,
+				8AEAAC252604EF420084FB85 /* BPSwimlane.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bluepill/src/BPRunner.h
+++ b/bluepill/src/BPRunner.h
@@ -15,7 +15,7 @@
 
 @property (nonatomic, strong) BPConfiguration *config;
 @property (nonatomic, strong) NSString *bpExecutable;
-@property (nonatomic, strong) NSMutableArray *nsTaskList;
+@property (nonatomic, strong) NSMutableArray *swimlaneList;
 @property (nonatomic, strong) NSDictionary *testHostSimTemplates;
 
 /*!
@@ -27,24 +27,14 @@
 + (instancetype)BPRunnerWithConfig:(BPConfiguration *)config
                         withBpPath:(NSString *)bpPath;
 
-/*!
- * @discussion Create a new Simulator wrapped in a `bp` process. It will run the specified bundle and execute the block once it finishes.
- * @param bundle The test bundle to execute.
- * @param number The simulator number (will be printed in logs).
- * @param block A completion block to execute when the NSTask has finished.
- * @return An NSTask ready to be executed via [task launch] or nil in failure.
- *
- */
-- (NSTask *)newTaskWithBundle:(BPXCTestFile *)bundle
-                    andNumber:(NSUInteger)number
-                    andDevice:(NSString *)deviceID
-           andCompletionBlock:(void (^)(NSTask * ))block;
-
 /**
  @discussion start running tests
  @return 1: test failures 0: pass -1: failed to run tests
  */
 - (int)runWithBPXCTestFiles:(NSArray<BPXCTestFile *>*)xcTestFiles;
 
-- (void) interrupt;
+- (void)interrupt;
+
+- (NSUInteger)busySwimlaneCount;
+
 @end

--- a/bluepill/src/BPSwimlane.h
+++ b/bluepill/src/BPSwimlane.h
@@ -1,0 +1,44 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "bp/src/BPXCTestFile.h"
+#import "bp/src/BPConfiguration.h"
+
+@interface BPSwimlane : NSObject
+
+@property (nonatomic, assign) BOOL isBusy;
+@property (nonatomic, assign) NSUInteger taskNumber;
+
+/*!
+ * @discussion get a BPSwimlane to execute `bp`.
+ * @param laneID the Lane ID that keeps the same for `bp` tasks.
+ * @return return the BPSwimlane.
+ */
++ (instancetype)BPSwimlaneWithLaneID:(NSUInteger)laneID;
+
+/*!
+ * @discussion Launch a NSTask to create a new Simulator wrapped in a `bp` process. It will run the specified bundle and execute the block once it finishes.
+ * @param bundle The test bundle to execute.
+ * @param config The BPConfiguration of the BPRunner.
+ * @param number The simulator number (will be printed in logs). *
+ * @param block A completion block to execute when the NSTask has finished.
+ *
+ */
+- (void)launchTaskWithBundle:(BPXCTestFile *)bundle
+                   andConfig:(BPConfiguration *)config
+               andLaunchPath:(NSString *)launchPath
+                   andNumber:(NSUInteger)number
+                   andDevice:(NSString *)deviceID
+          andTemplateSimUDID:(NSString *)templateSimUDID
+          andCompletionBlock:(void (^)(NSTask *))block;
+
+- (void)interrupt;
+
+@end

--- a/bluepill/src/BPSwimlane.m
+++ b/bluepill/src/BPSwimlane.m
@@ -1,0 +1,113 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+#import "bp/src/BPUtils.h"
+#import "BPSwimlane.h"
+
+@interface BPSwimlane()
+
+@property (nonatomic, assign) NSUInteger laneID;
+@property (nonatomic, strong) NSTask *task;
+
+@end
+
+@implementation BPSwimlane
+
++ (instancetype)BPSwimlaneWithLaneID:(NSUInteger)laneID {
+    BPSwimlane *bpTask = [[BPSwimlane alloc] init];
+    bpTask.laneID = laneID;
+    return bpTask;
+}
+
+- (void)launchTaskWithBundle:(BPXCTestFile *)bundle
+                   andConfig:(BPConfiguration *)config
+               andLaunchPath:(NSString *)launchPath
+                   andNumber:(NSUInteger)number
+                   andDevice:(NSString *)deviceID
+          andTemplateSimUDID:(NSString *)templateSimUDID
+          andCompletionBlock:(void (^)(NSTask *))block {
+    self.isBusy = YES;
+    self.taskNumber = number;
+
+    BPConfiguration *cfg = [config mutableCopy];
+    assert(cfg);
+    cfg.appBundlePath = bundle.UITargetAppPath ?: bundle.testHostPath;
+    cfg.testBundlePath = bundle.testBundlePath;
+    cfg.testRunnerAppPath = bundle.UITargetAppPath ? bundle.testHostPath : nil;
+    cfg.testCasesToSkip = bundle.skipTestIdentifiers;
+    if (cfg.commandLineArguments) {
+        [cfg.commandLineArguments arrayByAddingObjectsFromArray:bundle.commandLineArguments];
+    } else {
+        cfg.commandLineArguments = bundle.commandLineArguments;
+    }
+    if (cfg.environmentVariables) {
+        NSMutableDictionary *newEnv = [[NSMutableDictionary alloc] initWithDictionary:cfg.environmentVariables];
+        for (NSString *key in bundle.environmentVariables) {
+            newEnv[key] = bundle.environmentVariables[key];
+        }
+        cfg.environmentVariables = (NSDictionary<NSString *, NSString *>*) newEnv;
+    } else {
+        cfg.environmentVariables = bundle.environmentVariables;
+    }
+    cfg.dependencies = bundle.dependencies;
+    if (config.cloneSimulator) {
+        cfg.templateSimUDID = templateSimUDID;
+    }
+    NSError *err;
+    NSString *tmpFileName = [NSString stringWithFormat:@"%@/bluepill-%u-config",
+                             NSTemporaryDirectory(),
+                             getpid()];
+
+    cfg.configOutputFile = [BPUtils mkstemp:tmpFileName withError:&err];
+    if (!cfg.configOutputFile) {
+        fprintf(stderr, "ERROR: %s\n", [[err localizedDescription] UTF8String]);
+        return;
+    }
+    cfg.outputDirectory = [config.outputDirectory
+                           stringByAppendingPathComponent:
+                           [NSString stringWithFormat:@"BP-%lu", (unsigned long)number]];
+    cfg.testTimeEstimatesJsonFile = config.testTimeEstimatesJsonFile;
+    [cfg printConfig];
+
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:launchPath];
+    [task setArguments:@[@"-c", cfg.configOutputFile]];
+    NSMutableDictionary *env = [[NSMutableDictionary alloc] init];
+    [env addEntriesFromDictionary:[[NSProcessInfo processInfo] environment]];
+    [env setObject:[NSString stringWithFormat:@"%lu", number] forKey:@"_BP_NUM"];
+    [env setObject:[NSString stringWithFormat:@"%lu", self.laneID] forKey:@"_BP_INDEX"];
+    [task setEnvironment:env];
+    [task setTerminationHandler:^(NSTask *task) {
+        self.isBusy = NO;
+        self.task = nil;
+
+        [[NSFileManager defaultManager] removeItemAtPath:cfg.configOutputFile
+                                                   error:nil];
+        [BPUtils printInfo:INFO withString:@"BP-%lu (PID %u) has finished with exit code %d.",
+                                            number, [task processIdentifier], [task terminationStatus]];
+        block(task);
+    }];
+
+    if (!task) {
+        self.isBusy = NO;
+        [BPUtils printInfo:ERROR withString:@"task is nil!"];
+        exit(1);
+    }
+
+    [task launch];
+    self.task = task;
+    [BPUtils printInfo:INFO withString:@"Started BP-%lu (PID %d).", number, [task processIdentifier]];
+}
+
+- (void)interrupt {
+    [self.task interrupt];
+    self.isBusy = NO;
+}
+
+@end

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -223,7 +223,8 @@
     [jsonData writeToFile:[BPTestHelper testPlanPath] atomically:YES];
 }
 
-- (void)testTwoBPInstancesWithVideo {
+// TODO: Enable this when we figure out issue #469
+- (void)DISABLE_testTwoBPInstancesWithVideo {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *mkdtempError;
     NSString *path = [BPUtils mkdtemp:@"bpout" withError:&mkdtempError];

--- a/bluepill/tests/BPIntegrationTests.m
+++ b/bluepill/tests/BPIntegrationTests.m
@@ -70,7 +70,7 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0, @"Wanted 0, got %d", rc);
-    XCTAssert([runner.nsTaskList count] == 0);
+    XCTAssert([runner busySwimlaneCount] == 0);
 }
 
 - (void)testTwoBPInstances {
@@ -87,7 +87,7 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
-    XCTAssert([runner.nsTaskList count] == 0);
+    XCTAssert([runner busySwimlaneCount] == 0);
 }
 
 - (void)testClonedSimulators {
@@ -108,7 +108,7 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
-    XCTAssert([runner.nsTaskList count] == 0);
+    XCTAssert([runner busySwimlaneCount] == 0);
 }
 
 - (void)testTwoBPInstancesWithUITests {
@@ -131,7 +131,7 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
-    XCTAssert([runner.nsTaskList count] == 0);
+    XCTAssert([runner busySwimlaneCount] == 0);
 }
 
 - (void)testTwoBPInstancesWithXCTestRunFile {
@@ -171,7 +171,7 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc != 0);
-    XCTAssert([runner.nsTaskList count] == 0);
+    XCTAssert([runner busySwimlaneCount] == 0);
 }
 
 - (void)testTwoBPInstancesWithTestPlanJson {
@@ -251,7 +251,7 @@
     XCTAssert(dryRunRunner != nil);
     int dryRunRC = [dryRunRunner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(dryRunRC == 0);
-    XCTAssert([dryRunRunner.nsTaskList count] == 0);
+    XCTAssert([dryRunRunner busySwimlaneCount] == 0);
     [fileManager removeItemAtPath:videoPath error:nil];
     NSArray *dryRunOutputContents  = [fileManager  contentsOfDirectoryAtPath:videoPath error:nil];
     XCTAssertEqual(dryRunOutputContents.count, 0);
@@ -261,8 +261,8 @@
     XCTAssert(runner != nil);
     int rc = [runner runWithBPXCTestFiles:app.testBundles];
     XCTAssert(rc == 0);
-    XCTAssert([runner.nsTaskList count] == 0);
-    
+    XCTAssert([runner busySwimlaneCount] == 0);
+
     NSError *dirContentsError;
     NSArray *directoryContent  = [fileManager contentsOfDirectoryAtPath:videoPath error:&dirContentsError];
     XCTAssertNil(dirContentsError);

--- a/bp/src/BPStats.m
+++ b/bp/src/BPStats.m
@@ -184,10 +184,11 @@
 
 - (void)generateFullReportWithWriter:(BPWriter *)writer exitCode:(int)exitCode {
     unsigned long bundleID = [self bundleID];
+    unsigned long bpNum = [self bpNum];
     // Metadata
     NSString *threadName = @"Bluepill";
     if (bundleID > 0) {
-        threadName = [NSString stringWithFormat:@"BP-%lu", bundleID];
+        threadName = [NSString stringWithFormat:@"BP Swimlane #%lu", bundleID];
     }
     [writer writeLine:[NSString stringWithFormat:@"{\"name\": \"thread_name\", \"ph\": \"M\", \"pid\": 1, \"tid\": %lu, \"args\": {\"name\": \"%@\"}},",
                        bundleID,
@@ -199,7 +200,11 @@
                        bundleID
                        ]];
 
-    NSString *name = [NSString stringWithFormat:@"%s (%d)", (bundleID > 0) ? "bp" : "bluepill", getpid()];
+    NSString *bundleName = @"Bluepill";
+    if (bpNum > 0) {
+        bundleName = [NSString stringWithFormat:@"BP-%lu", bpNum];
+    }
+    NSString *name = [NSString stringWithFormat:@"%@ (%d)", bundleName, getpid()];
     [writer writeLine:[NSString stringWithFormat:@"%@,",
                        [self completeEvent:name
                                        cat:@"process"
@@ -231,12 +236,21 @@
 #pragma mark Trace Event Formatting
 
 -(unsigned long)bundleID {
-    char *s = getenv("_BP_NUM");
+    char *s = getenv("_BP_INDEX");
     if (!s) {
         s = "0";
     }
     unsigned long bundleID = strtoul(s, 0, 10);
     return bundleID;
+}
+
+-(unsigned long)bpNum {
+    char *s = getenv("_BP_NUM");
+    if (!s) {
+        s = "0";
+    }
+    unsigned long bpNum = strtoul(s, 0, 10);
+    return bpNum;
 }
 
 - (NSString *)resultToCname:(NSString *)result {


### PR DESCRIPTION
Moved all NSTask-related code into BPSwimlane.
BPSwimlane is in charge of launching tasks to run test bundles.
BPSwimlane holds LaneID which keeps the same when reused, so the logs are in one lane in tracing-profile.

---

Same with the [PR to master.](https://github.com/linkedin/bluepill/pull/486)
