### PR TITLE
Build bluepill and bp universal binary

### DIFF
--- a/bluepill/bluepill.xcodeproj/project.pbxproj
+++ b/bluepill/bluepill.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 			baseConfigurationReference = BAFCCA361E33595F00E33C31 /* bluepill.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -457,7 +457,7 @@
 			baseConfigurationReference = BAFCCA361E33595F00E33C31 /* bluepill.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -507,7 +507,7 @@
 		BAEF4B3C1DAC539400E68294 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_IDENTITY = "-";
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPER_PRIVATE_FRAMEWORKS_DIR = "";
@@ -529,7 +529,7 @@
 		BAEF4B3D1DAC539400E68294 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CODE_SIGN_IDENTITY = "-";
 				DEPLOYMENT_LOCATION = NO;
 				DEVELOPER_PRIVATE_FRAMEWORKS_DIR = "";

--- a/bp/bp.xcodeproj/project.pbxproj
+++ b/bp/bp.xcodeproj/project.pbxproj
@@ -910,7 +910,7 @@
 			baseConfigurationReference = 7A79018C1D5CF113004D4325 /* bp.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -968,7 +968,7 @@
 			baseConfigurationReference = 7A79018C1D5CF113004D4325 /* bp.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1099,7 +1099,7 @@
 		B368E56B213F8D2F00B4DEA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -1138,7 +1138,7 @@
 		B368E56C213F8D2F00B4DEA3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = x86_64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_ENABLE_OBJC_WEAK = YES;

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -70,23 +70,23 @@ bluepill_build()
   echo Release in "build/$DST.zip"
 }
 
-# bluepill_build_sample_app()
-# {
-#   set -o pipefail
-#   xcodebuild build-for-testing \
-#     -workspace Bluepill.xcworkspace \
-#     -arch x86_64 \
-#     -scheme BPSampleApp \
-#     -sdk iphonesimulator \
-#     -derivedDataPath "$DerivedDataPath" 2>&1 | tee result.txt | $XCPRETTY
+bluepill_build_sample_app()
+{
+  set -o pipefail
+  xcodebuild build-for-testing \
+    -workspace Bluepill.xcworkspace \
+    -arch x86_64 \
+    -scheme BPSampleApp \
+    -sdk iphonesimulator \
+    -derivedDataPath "$DerivedDataPath" 2>&1 | tee result.txt | $XCPRETTY
 
-#   test $? == 0 || {
-#           echo Build failed
-#           cat result.txt
-#           exit 1
-#   }
-#   set +o pipefail
-# }
+  test $? == 0 || {
+          echo Build failed
+          cat result.txt
+          exit 1
+  }
+  set +o pipefail
+}
 
 # $1 scheme, $2 extra args for xcodebuild
 run_tests() {

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -70,23 +70,23 @@ bluepill_build()
   echo Release in "build/$DST.zip"
 }
 
-bluepill_build_sample_app()
-{
-  set -o pipefail
-  xcodebuild build-for-testing \
-    -workspace Bluepill.xcworkspace \
-    -arch x86_64 \
-    -scheme BPSampleApp \
-    -sdk iphonesimulator \
-    -derivedDataPath "$DerivedDataPath" 2>&1 | tee result.txt | $XCPRETTY
+# bluepill_build_sample_app()
+# {
+#   set -o pipefail
+#   xcodebuild build-for-testing \
+#     -workspace Bluepill.xcworkspace \
+#     -arch x86_64 \
+#     -scheme BPSampleApp \
+#     -sdk iphonesimulator \
+#     -derivedDataPath "$DerivedDataPath" 2>&1 | tee result.txt | $XCPRETTY
 
-  test $? == 0 || {
-          echo Build failed
-          cat result.txt
-          exit 1
-  }
-  set +o pipefail
-}
+#   test $? == 0 || {
+#           echo Build failed
+#           cat result.txt
+#           exit 1
+#   }
+#   set +o pipefail
+# }
 
 # $1 scheme, $2 extra args for xcodebuild
 run_tests() {


### PR DESCRIPTION
Currently we are building bluepill and bp binaries for x86_64 arch. We should build the universal binary.

With this PR now both binaries are universal

`file build/Bluepill-v5.13.0-2-gf5211e8/bin/bluepill`
```
build/Bluepill-v5.13.0-2-gf5211e8/bin/bluepill: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
build/Bluepill-v5.13.0-2-gf5211e8/bin/bluepill (for architecture x86_64):       Mach-O 64-bit executable x86_64
build/Bluepill-v5.13.0-2-gf5211e8/bin/bluepill (for architecture arm64):        Mach-O 64-bit executable arm64
```

`file build/Bluepill-v5.13.0-2-gf5211e8/bin/bp`
```
build/Bluepill-v5.13.0-2-gf5211e8/bin/bp: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
build/Bluepill-v5.13.0-2-gf5211e8/bin/bp (for architecture x86_64):     Mach-O 64-bit executable x86_64
build/Bluepill-v5.13.0-2-gf5211e8/bin/bp (for architecture arm64):      Mach-O 64-bit executable arm64
```